### PR TITLE
Add security patch for FLAC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ The repository consists mostly of externally hosted subrepositories:
 .. _flac: https://github.com/xiph/flac
 .. |flaclic| replace:: LGPL v2.1 license
 .. _flaclic: https://github.com/xiph/flac/blob/master/COPYING.LGPL
-.. |flacver| replace:: 1.3.3
+.. |flacver| replace:: 1.3.3 (+ security patch)
 .. _flacver: https://github.com/xiph/flac/releases/tag/1.3.3
 
 .. _FFmpeg: https://github.com/FFmpeg/FFmpeg

--- a/build_scripts/build_libflac.sh
+++ b/build_scripts/build_libflac.sh
@@ -16,6 +16,9 @@
 
 # flac
 pushd third_party/flac
+
+patch --no-backup-if-mismatch -p1 < ${ROOT_DIR}/patches/0001-libFLAC-bitreader.c-Fix-out-of-bounds-read.patch
+
 ./autogen.sh
 ./configure \
   CFLAGS="-fPIC ${EXTRA_FLAC_FLAGS}" \
@@ -27,4 +30,5 @@ pushd third_party/flac
   --disable-ogg
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 make install
+
 popd

--- a/patches/0001-libFLAC-bitreader.c-Fix-out-of-bounds-read.patch
+++ b/patches/0001-libFLAC-bitreader.c-Fix-out-of-bounds-read.patch
@@ -1,0 +1,28 @@
+From 2e7931c27eb15e387da440a37f12437e35b22dd4 Mon Sep 17 00:00:00 2001
+From: Erik de Castro Lopo <erikd@mega-nerd.com>
+Date: Mon, 7 Oct 2019 12:55:58 +1100
+Subject: [PATCH] libFLAC/bitreader.c: Fix out-of-bounds read
+
+Credit: Oss-Fuzz
+Issue: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17069
+Testcase: fuzzer_decoder-5670265022840832
+---
+ src/libFLAC/bitreader.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libFLAC/bitreader.c b/src/libFLAC/bitreader.c
+index 5e4b5918..3df4d02c 100644
+--- a/src/libFLAC/bitreader.c
++++ b/src/libFLAC/bitreader.c
+@@ -869,7 +869,7 @@ incomplete_lsbs:
+ 			cwords = br->consumed_words;
+ 			words = br->words;
+ 			ucbits = FLAC__BITS_PER_WORD - br->consumed_bits;
+-			b = br->buffer[cwords] << br->consumed_bits;
++			b = cwords < br->capacity ? br->buffer[cwords] << br->consumed_bits : 0;
+ 		} while(cwords >= words && val < end);
+ 	}
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Adds a patch to fix an out-of-bounds vulnerability in libflac 1.3.3
https://github.com/xiph/flac/commit/2e7931c27eb15e387da440a37f12437e35b22dd4

To be removed once the commit is available in a libflac release.

Signed-off-by: Joaquin Anton <janton@nvidia.com>