### PR TITLE
Add a DALI prefix to FFmpeg symbol versions

### DIFF
--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -55,6 +55,8 @@ if [ ${WITH_FFMPEG} -gt 0 ]; then
         --disable-filters \
         --disable-bsfs \
         --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb,mpeg4_unpack_bframes
+    # adds | sed 's/\(.*{\)/DALI_\1/' | to the version file generation command - it prepends "DALI_" to the symbol version
+    sed -i 's/\$\$(M)sed '\''s\/MAJOR\/\$(lib$(NAME)_VERSION_MAJOR)\/'\'' \$\$< | \$(VERSION_SCRIPT_POSTPROCESS_CMD) > \$\$\@/\$\$(M)sed '\''s\/MAJOR\/\$(lib$(NAME)_VERSION_MAJOR)\/'\'' \$\$< | sed '\''s\/\\(\.*{\\)\/DALI_\\1\/'\'' | \$(VERSION_SCRIPT_POSTPROCESS_CMD) > \$\$\@/' ffbuild/library.mak
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
     make install
     popd


### PR DESCRIPTION
- DALI uses a custom FFmpeg build so in case other process
  imports FFmpeg before DALI is loaded DALI will use symbols
  from it instead of the custom version it ships. Adding a custom
  symbol version should avid this symbol clash

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>