### PR TITLE
Fix build errors for builds for non-standard build locations

### DIFF
--- a/build_scripts/build_cmake.sh
+++ b/build_scripts/build_cmake.sh
@@ -16,7 +16,7 @@
 
 # CMake
 pushd third_party/CMake
-./bootstrap --parallel=$(grep ^processor /proc/cpuinfo | wc -l) --prefix=${INSTALL_PREFIX}
+./bootstrap --parallel=$(grep ^processor /proc/cpuinfo | wc -l) --prefix=${HOST_INSTALL_PREFIX}
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 make install
 popd

--- a/build_scripts/build_cmake.sh
+++ b/build_scripts/build_cmake.sh
@@ -16,7 +16,7 @@
 
 # CMake
 pushd third_party/CMake
-./bootstrap --parallel=$(grep ^processor /proc/cpuinfo | wc -l)
+./bootstrap --parallel=$(grep ^processor /proc/cpuinfo | wc -l) --prefix=${INSTALL_PREFIX}
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 make install
 popd

--- a/build_scripts/build_deps.sh
+++ b/build_scripts/build_deps.sh
@@ -16,7 +16,8 @@
 
 export ROOT_DIR=$(pwd)
 export SCRIPT_DIR=$(cd $(dirname $0) && pwd)
-export INSTALL_PREFIX=${INSTALL_PREFIX:-/usr/local}
+export HOST_INSTALL_PREFIX=${HOST_INSTALL_PREFIX:-/usr/local}
+export INSTALL_PREFIX=${INSTALL_PREFIX:-$HOST_INSTALL_PREFIX}
 export CC_COMP=${CC_COMP:-gcc}
 export CXX_COMP=${CXX_COMP:-g++}
 export WITH_FFMPEG=${WITH_FFMPEG:-1}

--- a/build_scripts/build_lmdb.sh
+++ b/build_scripts/build_lmdb.sh
@@ -19,5 +19,5 @@ pushd third_party/lmdb/libraries/liblmdb/
 patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
     CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
-make install
+prefix=${INSTALL_PREFIX} DESTDIR="" make install
 popd

--- a/build_scripts/build_lmdb.sh
+++ b/build_scripts/build_lmdb.sh
@@ -19,5 +19,5 @@ pushd third_party/lmdb/libraries/liblmdb/
 patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
     CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
-prefix=${INSTALL_PREFIX} DESTDIR="" make install
+prefix=${INSTALL_PREFIX} make install
 popd

--- a/build_scripts/build_opencv.sh
+++ b/build_scripts/build_opencv.sh
@@ -16,7 +16,7 @@
 
 # OpenCV
 pushd third_party/opencv
-mkdir build
+mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=RELEASE \
       -DVIBRANTE_PDK:STRING=/ \
@@ -38,6 +38,7 @@ cmake -DCMAKE_BUILD_TYPE=RELEASE \
       -DBUILD_TESTS=OFF \
       -DBUILD_PERF_TESTS=OFF \
       -DBUILD_PNG=ON \
+      -DWITH_WEBP=ON \
       -DBUILD_opencv_cudalegacy=OFF \
       -DBUILD_opencv_stitching=OFF \
       -DWITH_TBB=OFF \

--- a/build_scripts/build_openjpeg.sh
+++ b/build_scripts/build_openjpeg.sh
@@ -16,7 +16,7 @@
 
 # OpenJPEG
 pushd third_party/openjpeg
-mkdir build
+mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
 echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -17,7 +17,7 @@
 # protobuf, make two steps for cross compilation if needed
 pushd third_party/protobuf
 ./autogen.sh
-./configure CXXFLAGS="-fPIC" --prefix=${INSTALL_PREFIX} --disable-shared 2>&1 > /dev/null
+./configure CXXFLAGS="-fPIC" --prefix=${HOST_INSTALL_PREFIX} --disable-shared 2>&1 > /dev/null
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)" 2>&1 > /dev/null
 make install 2>&1 > /dev/null
 # only when cross compiling

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -17,7 +17,7 @@
 # protobuf, make two steps for cross compilation if needed
 pushd third_party/protobuf
 ./autogen.sh
-./configure CXXFLAGS="-fPIC" --prefix=/usr/local --disable-shared 2>&1 > /dev/null
+./configure CXXFLAGS="-fPIC" --prefix=${INSTALL_PREFIX} --disable-shared 2>&1 > /dev/null
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)" 2>&1 > /dev/null
 make install 2>&1 > /dev/null
 # only when cross compiling
@@ -31,7 +31,7 @@ if [ "${CC_COMP}" != "gcc" ]; then
       ${HOST_ARCH_OPTION} \
       ${BUILD_ARCH_OPTION} \
       ${SYSROOT_ARG} \
-      --with-protoc=/usr/local/bin/protoc \
+      --with-protoc=${INSTALL_PREFIX}/bin/protoc \
       --prefix=${INSTALL_PREFIX}
   make -j$(nproc) install
 fi

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -31,7 +31,7 @@ if [ "${CC_COMP}" != "gcc" ]; then
       ${HOST_ARCH_OPTION} \
       ${BUILD_ARCH_OPTION} \
       ${SYSROOT_ARG} \
-      --with-protoc=${INSTALL_PREFIX}/bin/protoc \
+      --with-protoc=${HOST_INSTALL_PREFIX}/bin/protoc \
       --prefix=${INSTALL_PREFIX}
   make -j$(nproc) install
 fi

--- a/patches/Makefile-lmdb.patch
+++ b/patches/Makefile-lmdb.patch
@@ -1,5 +1,5 @@
 diff --git a/libraries/liblmdb/Makefile b/libraries/liblmdb/Makefile
-index f254511..06c473a 100644
+index f254511..808eba7 100644
 --- a/libraries/liblmdb/Makefile
 +++ b/libraries/liblmdb/Makefile
 @@ -18,8 +18,8 @@
@@ -22,7 +22,7 @@ index f254511..06c473a 100644
  exec_prefix = $(prefix)
  bindir = $(exec_prefix)/bin
  libdir = $(exec_prefix)/lib
-@@ -38,18 +38,16 @@ mandir = $(datarootdir)/man
+@@ -38,21 +38,19 @@ mandir = $(datarootdir)/man
  ########################################################################
  
  IHDRS	= lmdb.h
@@ -32,18 +32,28 @@ index f254511..06c473a 100644
  IDOCS	= mdb_stat.1 mdb_copy.1 mdb_dump.1 mdb_load.1
  PROGS	= $(IPROGS) mtest mtest2 mtest3 mtest4 mtest5
 -all:	$(ILIBS) $(PROGS)
-+all:	$(ILIBS)
- 
+-
 -install: $(ILIBS) $(IPROGS) $(IHDRS)
 -	mkdir -p $(DESTDIR)$(bindir)
-+install: $(ILIBS) $(IHDRS)
- 	mkdir -p $(DESTDIR)$(libdir)
- 	mkdir -p $(DESTDIR)$(includedir)
- 	mkdir -p $(DESTDIR)$(mandir)/man1
+-	mkdir -p $(DESTDIR)$(libdir)
+-	mkdir -p $(DESTDIR)$(includedir)
+-	mkdir -p $(DESTDIR)$(mandir)/man1
 -	for f in $(IPROGS); do cp $$f $(DESTDIR)$(bindir); done
- 	for f in $(ILIBS); do cp $$f $(DESTDIR)$(libdir); done
- 	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includedir); done
- 	for f in $(IDOCS); do cp $$f $(DESTDIR)$(mandir)/man1; done
+-	for f in $(ILIBS); do cp $$f $(DESTDIR)$(libdir); done
+-	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includedir); done
+-	for f in $(IDOCS); do cp $$f $(DESTDIR)$(mandir)/man1; done
++all:	$(ILIBS)
++
++install: $(ILIBS) $(IHDRS)
++	mkdir -p $(libdir)
++	mkdir -p $(includedir)
++	mkdir -p $(mandir)/man1
++	for f in $(ILIBS); do cp $$f $(libdir); done
++	for f in $(IHDRS); do cp $$f $(includedir); done
++	for f in $(IDOCS); do cp $$f $(mandir)/man1; done
+ 
+ clean:
+ 	rm -rf $(PROGS) *.[ao] *.[ls]o *~ testdb
 @@ -61,8 +59,8 @@ test:	all
  	rm -rf testdb && mkdir testdb
  	./mtest && ./mdb_stat testdb


### PR DESCRIPTION
While preparing for the addition of [WebP support for DALI](https://github.com/NVIDIA/DALI/issues/3203), I wanted to build the DALI deps from source. Being on a machine without root access, I choose a PREFIX inside my home directory and encountered several errors. Since this repo does not have an issues section, this PR is semi-PR and semi-discussion.

Explanation of my changes:
- `build_protobuf` and `build_cmake` had hardcoded paths so I changed them.
- `build_opencv` and `build_openjpeg` use `mkdir build` which will crash if the folder already exists. This was kinda annoying during my debugging so I changed it to `mkdir -p. Does this have any negative side effects you are aware of?
- The `lmdb` Makefile is somewhat confusing to me because it uses both `DESTDIR` and `prefix` in the `install target`. Maybe my knowledge of Makefiles is too limited but in my opinion this is redundant. In any way, since the `lmdb` repo does not use CMake or autoconf, I had to prepend `prefix` on the `make install` call again. `DESTDIR=""` is a hack I chose because of the redundancy. Maybe a patch would be a cleaner solution here? I wasn't sure how to create a proper patch file here though.
- I added `WITH_WEBP=ON` to `build_opencv` in prepration for [DALI#3203](https://github.com/NVIDIA/DALI/issues/3203). I only added this before posting a PR to the main DALI repo because according to the [OpenCV docs](https://docs.opencv.org/4.5.2/db/d05/tutorial_config_reference.html), `WITH_WEBP=ON` is the default setting so making this explicit shouldn't actually change anything.

On a side note: Building FFmpeg with `build_ffmpeg` using the `nasm` assembler did not work on my machine (AMD Epyc 7742, Ubuntu 20.04 LTS) unless I disabled the MMX instruction set. `yasm` on the other hand worked fine so maybe it would be helpful to add a note to the DALI build from source guide to use `yasm` over `nasm` for FFmpeg.