### PR TITLE
Fix FFmpeg vulnerabilities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ The repository consists mostly of externally hosted subrepositories:
 .. |FFmpegver| replace:: 4.4 (+ Security Patch)
 .. _FFmpegver: https://github.com/FFmpeg/FFmpeg/releases/tag/n4.4
 .. |FFmpegsrc| replace:: (Source Snapshot)
-.. _FFmpegsrc: https://developer.download.nvidia.com/compute/redist/nvidia-dali/FFmpeg-n4.4_v2.tar.gz
+.. _FFmpegsrc: https://developer.download.nvidia.com/compute/redist/nvidia-dali/FFmpeg-n4.4_v3.tar.gz
 
 .. _opencv: https://github.com/opencv/opencv/
 .. |opencvlic| replace:: Apache License 2.0

--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -23,6 +23,9 @@ if [ ${WITH_FFMPEG} -gt 0 ]; then
     patch -p1 < ${ROOT_DIR}/patches/FFmpeg-CVE-2020-22021.patch
     patch -p1 < ${ROOT_DIR}/patches/FFmpeg-CVE-2020-22015.patch
     patch -p1 < ${ROOT_DIR}/patches/FFmpeg-CVE-2021-38114.patch
+    patch -p1 < ${ROOT_DIR}/patches/FFmpeg-CVE-2021-38171.patch
+    patch -p1 < ${ROOT_DIR}/patches/FFmpeg-CVE-2021-38291.patch
+    patch -p1 < ${ROOT_DIR}/patches/FFmpeg-CVE-2020-22037.patch
     ./configure \
         --prefix=${INSTALL_PREFIX} \
         --disable-static \

--- a/patches/FFmpeg-CVE-2020-22037.patch
+++ b/patches/FFmpeg-CVE-2020-22037.patch
@@ -1,0 +1,79 @@
+From 7bba0dd6382e30d646cb406034a66199e071d713 Mon Sep 17 00:00:00 2001
+From: Michael Niedermayer <michael@niedermayer.cc>
+Date: Sat, 14 Aug 2021 09:55:00 +0200
+Subject: [PATCH] avcodec/frame_thread_encoder: Free AVCodecContext structure
+ on error during init
+
+Fixes: MemLeak
+Fixes: 8281
+Fixes: PoC_option158.jpg
+Fixes: CVE-2020-22037
+
+Reviewed-by: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/frame_thread_encoder.c | 11 +++++++----
+ libavcodec/frame_thread_encoder.h |  4 ++++
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/libavcodec/frame_thread_encoder.c b/libavcodec/frame_thread_encoder.c
+index 9cabfc495f..9bc48c7761 100644
+--- a/libavcodec/frame_thread_encoder.c
++++ b/libavcodec/frame_thread_encoder.c
+@@ -126,7 +126,7 @@ int ff_frame_thread_encoder_init(AVCodecContext *avctx)
+ {
+     int i=0;
+     ThreadContext *c;
+-
++    AVCodecContext *thread_avctx = NULL;
+
+     if(   !(avctx->thread_type & FF_THREAD_FRAME)
+        || !(avctx->codec->capabilities & AV_CODEC_CAP_FRAME_THREADS))
+@@ -202,16 +202,17 @@ int ff_frame_thread_encoder_init(AVCodecContext *avctx)
+     for(i=0; i<avctx->thread_count ; i++){
+         int ret;
+         void *tmpv;
+-        AVCodecContext *thread_avctx = avcodec_alloc_context3(avctx->codec);
++        thread_avctx = avcodec_alloc_context3(avctx->codec);
+         if(!thread_avctx)
+             goto fail;
+         tmpv = thread_avctx->priv_data;
+         *thread_avctx = *avctx;
++        thread_avctx->priv_data = tmpv;
++        thread_avctx->internal = NULL;
++        thread_avctx->hw_frames_ctx = NULL;
+         ret = av_opt_copy(thread_avctx, avctx);
+         if (ret < 0)
+             goto fail;
+-        thread_avctx->priv_data = tmpv;
+-        thread_avctx->internal = NULL;
+         if (avctx->codec->priv_class) {
+             int ret = av_opt_copy(thread_avctx->priv_data, avctx->priv_data);
+             if (ret < 0)
+@@ -233,6 +234,8 @@ int ff_frame_thread_encoder_init(AVCodecContext *avctx)
+
+     return 0;
+ fail:
++    avcodec_close(thread_avctx);
++    av_freep(&thread_avctx);
+     avctx->thread_count = i;
+     av_log(avctx, AV_LOG_ERROR, "ff_frame_thread_encoder_init failed\n");
+     ff_frame_thread_encoder_free(avctx);
+diff --git a/libavcodec/frame_thread_encoder.h b/libavcodec/frame_thread_encoder.h
+index 2cdc40a830..201cba2a8f 100644
+--- a/libavcodec/frame_thread_encoder.h
++++ b/libavcodec/frame_thread_encoder.h
+@@ -23,6 +23,10 @@
+
+ #include "avcodec.h"
+
++/**
++ * Initialize frame thread encoder.
++ * @note hardware encoders are not supported
++ */
+ int ff_frame_thread_encoder_init(AVCodecContext *avctx, AVDictionary *options);
+ void ff_frame_thread_encoder_free(AVCodecContext *avctx);
+ int ff_thread_video_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
+--
+2.17.1
+

--- a/patches/FFmpeg-CVE-2021-38171.patch
+++ b/patches/FFmpeg-CVE-2021-38171.patch
@@ -1,0 +1,36 @@
+From 9ffa49496d1aae4cbbb387aac28a9e061a6ab0a6 Mon Sep 17 00:00:00 2001
+From: maryam ebrahimzadeh <me22bee@outlook.com>
+Date: Wed, 4 Aug 2021 16:15:18 -0400
+Subject: [PATCH] avformat/adtsenc: return value check for init_get_bits in
+ adts_decode_extradata
+
+As the second argument for init_get_bits (buf) can be crafted, a return value check for this function call is necessary.
+'buf' is  part of  'AVPacket pkt'.
+replace init_get_bits with init_get_bits8.
+
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavformat/adtsenc.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libavformat/adtsenc.c b/libavformat/adtsenc.c
+index ba15c0a724..3924e678d9 100644
+--- a/libavformat/adtsenc.c
++++ b/libavformat/adtsenc.c
+@@ -53,9 +53,11 @@ static int adts_decode_extradata(AVFormatContext *s, ADTSContext *adts, const ui
+     GetBitContext gb;
+     PutBitContext pb;
+     MPEG4AudioConfig m4ac;
+-    int off;
++    int off, ret;
+ 
+-    init_get_bits(&gb, buf, size * 8);
++    ret = init_get_bits8(&gb, buf, size);
++    if (ret < 0)
++        return ret;
+     off = avpriv_mpeg4audio_get_config2(&m4ac, buf, size, 1, s);
+     if (off < 0)
+         return off;
+-- 
+2.17.1
+

--- a/patches/FFmpeg-CVE-2021-38291.patch
+++ b/patches/FFmpeg-CVE-2021-38291.patch
@@ -1,0 +1,50 @@
+From e01d306c647b5827102260b885faa223b646d2d1 Mon Sep 17 00:00:00 2001
+From: James Almer <jamrial@gmail.com>
+Date: Wed, 21 Jul 2021 01:02:44 -0300
+Subject: [PATCH] avcodec/utils: don't return negative values in
+ av_get_audio_frame_duration()
+
+In some extrme cases, like with adpcm_ms samples with an extremely high channel
+count, get_audio_frame_duration() may return a negative frame duration value.
+Don't propagate it, and instead return 0, signaling that a duration could not
+be determined.
+
+Fixes ticket #9312
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+---
+ libavcodec/utils.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/utils.c b/libavcodec/utils.c
+index 5fad782f5a..cfc07cbcb8 100644
+--- a/libavcodec/utils.c
++++ b/libavcodec/utils.c
+@@ -810,20 +810,22 @@ static int get_audio_frame_duration(enum AVCodecID id, int sr, int ch, int ba,
+ 
+ int av_get_audio_frame_duration(AVCodecContext *avctx, int frame_bytes)
+ {
+-    return get_audio_frame_duration(avctx->codec_id, avctx->sample_rate,
++    int duration = get_audio_frame_duration(avctx->codec_id, avctx->sample_rate,
+                                     avctx->channels, avctx->block_align,
+                                     avctx->codec_tag, avctx->bits_per_coded_sample,
+                                     avctx->bit_rate, avctx->extradata, avctx->frame_size,
+                                     frame_bytes);
++    return FFMAX(0, duration);
+ }
+ 
+ int av_get_audio_frame_duration2(AVCodecParameters *par, int frame_bytes)
+ {
+-    return get_audio_frame_duration(par->codec_id, par->sample_rate,
++    int duration = get_audio_frame_duration(par->codec_id, par->sample_rate,
+                                     par->channels, par->block_align,
+                                     par->codec_tag, par->bits_per_coded_sample,
+                                     par->bit_rate, par->extradata, par->frame_size,
+                                     frame_bytes);
++    return FFMAX(0, duration);
+ }
+ 
+ #if !HAVE_THREADS
+-- 
+2.17.1
+


### PR DESCRIPTION
- fixes CVE-2020-22037
- fixes CVE-2021-38171
- fixes CVE-2021-38291
- updates FFmpeg build instruction by adding new link to the packed
  source code

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>