### PR TITLE
Fix libtiff build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ The repository consists mostly of externally hosted subrepositories:
 .. _libtiff: https://gitlab.com/libtiff/libtiff
 .. |libtifflic| replace:: BSD-2 license
 .. _libtifflic: https://gitlab.com/libtiff/libtiff/-/blob/master/README.md
-.. |libtiffver| replace:: 4.3.0
+.. |libtiffver| replace:: 4.3.0 (+ Build System Patch)
 .. _libtiffver: https://gitlab.com/libtiff/libtiff/-/tree/v4.3.0
 
 .. _zstd: https://github.com/facebook/zstd

--- a/build_scripts/build_libtiff.sh
+++ b/build_scripts/build_libtiff.sh
@@ -16,6 +16,7 @@
 
 # libtiff
 pushd third_party/libtiff
+patch -p1 < ${ROOT_DIR}/patches/0001-Fix-wget-complaing-about-expired-git.savannah.gnu.or.patch
 ./autogen.sh
 ./configure \
     CFLAGS="-fPIC" \

--- a/patches/0001-Fix-wget-complaing-about-expired-git.savannah.gnu.or.patch
+++ b/patches/0001-Fix-wget-complaing-about-expired-git.savannah.gnu.or.patch
@@ -1,0 +1,26 @@
+From 23d9e6e8f43632cc1313688ff7bf52494b134c52 Mon Sep 17 00:00:00 2001
+From: Janusz Lisiecki <jlisiecki@nvidia.com>
+Date: Thu, 30 Sep 2021 21:24:07 +0200
+Subject: [PATCH] Fix wget complaing about expired git.savannah.gnu.org cert
+
+Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>
+---
+ autogen.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index 9ef71b53..779fb28d 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -10,7 +10,7 @@ autoconf
+ for file in config.guess config.sub
+ do
+     echo "$0: getting $file..."
+-    wget -q --timeout=5 -O config/$file.tmp \
++    wget -q --timeout=5 --no-check-certificate -O config/$file.tmp \
+       "https://git.savannah.gnu.org/cgit/config.git/plain/${file}" \
+       && mv config/$file.tmp config/$file \
+       && chmod a+x config/$file
+-- 
+2.17.1
+


### PR DESCRIPTION
- libtiff during build downloads the latest configs from https://git.savannah.gnu.org
  and wget complains sometimes about expired certificate. To fix that
  during libtiff build a patch is applied to disregard the certificate

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>