### PR TITLE
Update libtiff CVE-2022-22844 patch to the latest version from https://gitlab.com/libtiff/libtiff/-/merge_requests/287

### DIFF
--- a/patches/libtiff-CVE-2022-22844.patch
+++ b/patches/libtiff-CVE-2022-22844.patch
@@ -1,18 +1,19 @@
-From 49b81e99704bd199a24ccce65f974cc2d78cccc4 Mon Sep 17 00:00:00 2001
+From 03047a26952a82daaa0792957ce211e0aa51bc64 Mon Sep 17 00:00:00 2001
 From: 4ugustus <wangdw.augustus@qq.com>
-Date: Tue, 4 Jan 2022 11:01:37 +0000
-Subject: [PATCH] fixing global-buffer-overflow in tiffset
+Date: Tue, 25 Jan 2022 16:25:28 +0000
+Subject: [PATCH] tiffset: fix global-buffer-overflow for ASCII tags where
+ count is required (fixes #355)
 
 ---
  tools/tiffset.c | 16 +++++++++++++---
  1 file changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/tools/tiffset.c b/tools/tiffset.c
-index 8c9e23c5..b7badd93 100644
+index 8c9e23c5..e7a88c09 100644
 --- a/tools/tiffset.c
 +++ b/tools/tiffset.c
 @@ -146,9 +146,19 @@ main(int argc, char* argv[])
-
+ 
              arg_index++;
              if (TIFFFieldDataType(fip) == TIFF_ASCII) {
 -                if (TIFFSetField(tiff, TIFFFieldTag(fip), argv[arg_index]) != 1)
@@ -20,19 +21,20 @@ index 8c9e23c5..b7badd93 100644
 -                             TIFFFieldName(fip), argv[arg_index] );
 +                if(TIFFFieldPassCount( fip )) {
 +                    size_t len;
-+                    len = (uint32_t)(strlen(argv[arg_index] + 1));
-+                    if (TIFFSetField(tiff, TIFFFieldTag(fip),
++                    len = strlen(argv[arg_index]) + 1;
++                    if (len > UINT16_MAX || TIFFSetField(tiff, TIFFFieldTag(fip),
 +                            (uint16_t)len, argv[arg_index]) != 1)
-+                        fprintf( stderr, "Failed to set %s=%s",
++                        fprintf( stderr, "Failed to set %s=%s\n",
 +                            TIFFFieldName(fip), argv[arg_index] );
 +                } else {
 +                    if (TIFFSetField(tiff, TIFFFieldTag(fip),
 +                            argv[arg_index]) != 1)
-+                        fprintf( stderr, "Failed to set %s=%s",
++                        fprintf( stderr, "Failed to set %s=%s\n",
 +                            TIFFFieldName(fip), argv[arg_index] );
 +                }
              } else if (TIFFFieldWriteCount(fip) > 0
  		       || TIFFFieldWriteCount(fip) == TIFF_VARIABLE) {
                  int     ret = 1;
---
-GitLab
+-- 
+2.25.1
+


### PR DESCRIPTION


Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>