### PR TITLE
Fix CVE-2022-0626 in libtiff

### DIFF
--- a/build_scripts/build_libtiff.sh
+++ b/build_scripts/build_libtiff.sh
@@ -19,6 +19,7 @@ pushd third_party/libtiff
 patch -p1 < ${ROOT_DIR}/patches/0001-Fix-wget-complaing-about-expired-git.savannah.gnu.or.patch
 patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-22844.patch
 patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-0561.patch
+patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-0626.patch
 ./autogen.sh
 ./configure \
     CFLAGS="-fPIC" \

--- a/patches/libtiff-CVE-2022-0626.patch
+++ b/patches/libtiff-CVE-2022-0626.patch
@@ -1,0 +1,34 @@
+From a1c933dabd0e1c54a412f3f84ae0aa58115c6067 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Thu, 24 Feb 2022 22:26:02 +0100
+Subject: [PATCH 1/1] tif_jbig.c: fix crash when reading a file with multiple
+ IFD in memory-mapped mode and when bit reversal is needed (fixes #385)
+
+---
+ libtiff/tif_jbig.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/libtiff/tif_jbig.c b/libtiff/tif_jbig.c
+index 74086338..8bfa4cef 100644
+--- a/libtiff/tif_jbig.c
++++ b/libtiff/tif_jbig.c
+@@ -209,6 +209,16 @@ int TIFFInitJBIG(TIFF* tif, int scheme)
+ 	 */
+ 	tif->tif_flags |= TIFF_NOBITREV;
+ 	tif->tif_flags &= ~TIFF_MAPPED;
++	/* We may have read from a previous IFD and thus set TIFF_BUFFERMMAP and
++	 * cleared TIFF_MYBUFFER. It is necessary to restore them to their initial
++	 * value to be consistent with the state of a non-memory mapped file.
++	 */
++	if (tif->tif_flags&TIFF_BUFFERMMAP) {
++		tif->tif_rawdata = NULL;
++		tif->tif_rawdatasize = 0;
++		tif->tif_flags &= ~TIFF_BUFFERMMAP;
++		tif->tif_flags |= TIFF_MYBUFFER;
++	}
+ 
+ 	/* Setup the function pointers for encode, decode, and cleanup. */
+ 	tif->tif_setupdecode = JBIGSetupDecode;
+-- 
+2.25.1
+


### PR DESCRIPTION
- see https://gitlab.com/libtiff/libtiff/-/issues/385 and
  https://gitlab.com/libtiff/libtiff/-/commit/5e18004500cda10d9074bdb6166b054e95b659ed

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>