### PR TITLE
Fix libtiff CVE-2022-2058, CVE-2022-2057, CVE-2022-2056

### DIFF
--- a/build_scripts/build_libtiff.sh
+++ b/build_scripts/build_libtiff.sh
@@ -17,6 +17,7 @@
 # libtiff
 pushd third_party/libtiff
 patch -p1 < ${ROOT_DIR}/patches/0001-Fix-wget-complaing-about-expired-git.savannah.gnu.or.patch
+patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-2057.patch
 ./autogen.sh
 ./configure \
     CFLAGS="-fPIC" \

--- a/patches/libtiff-CVE-2022-2057.patch
+++ b/patches/libtiff-CVE-2022-2057.patch
@@ -1,0 +1,180 @@
+From dd1bcc7abb26094e93636e85520f0d8f81ab0fab Mon Sep 17 00:00:00 2001
+From: 4ugustus <wangdw.augustus@qq.com>
+Date: Sat, 11 Jun 2022 09:31:43 +0000
+Subject: [PATCH] fix the FPE in tiffcrop (#415, #427, and #428)
+
+---
+ libtiff/tif_aux.c |  9 +++++++
+ libtiff/tiffiop.h |  1 +
+ tools/tiffcrop.c  | 62 ++++++++++++++++++++++++++---------------------
+ 3 files changed, 44 insertions(+), 28 deletions(-)
+
+diff --git a/libtiff/tif_aux.c b/libtiff/tif_aux.c
+index 140f26c7..5b88c8d0 100644
+--- a/libtiff/tif_aux.c
++++ b/libtiff/tif_aux.c
+@@ -402,6 +402,15 @@ float _TIFFClampDoubleToFloat( double val )
+     return (float)val;
+ }
+ 
++uint32_t _TIFFClampDoubleToUInt32(double val)
++{
++    if( val < 0 )
++        return 0;
++    if( val > 0xFFFFFFFFU || val != val )
++        return 0xFFFFFFFFU;
++    return (uint32_t)val;
++}
++
+ int _TIFFSeekOK(TIFF* tif, toff_t off)
+ {
+     /* Huge offsets, especially -1 / UINT64_MAX, can cause issues */
+diff --git a/libtiff/tiffiop.h b/libtiff/tiffiop.h
+index e3af461d..4e8bdac2 100644
+--- a/libtiff/tiffiop.h
++++ b/libtiff/tiffiop.h
+@@ -365,6 +365,7 @@ extern double _TIFFUInt64ToDouble(uint64_t);
+ extern float _TIFFUInt64ToFloat(uint64_t);
+ 
+ extern float _TIFFClampDoubleToFloat(double);
++extern uint32_t _TIFFClampDoubleToUInt32(double);
+ 
+ extern tmsize_t
+ _TIFFReadEncodedStripAndAllocBuffer(TIFF* tif, uint32_t strip,
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 1f827b2b..90286a5e 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -5268,17 +5268,17 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+       {
+       if ((crop->res_unit == RESUNIT_INCH) || (crop->res_unit == RESUNIT_CENTIMETER))
+         {
+-	x1 = (uint32_t) (crop->corners[i].X1 * scale * xres);
+-	x2 = (uint32_t) (crop->corners[i].X2 * scale * xres);
+-	y1 = (uint32_t) (crop->corners[i].Y1 * scale * yres);
+-	y2 = (uint32_t) (crop->corners[i].Y2 * scale * yres);
++	x1 = _TIFFClampDoubleToUInt32(crop->corners[i].X1 * scale * xres);
++	x2 = _TIFFClampDoubleToUInt32(crop->corners[i].X2 * scale * xres);
++	y1 = _TIFFClampDoubleToUInt32(crop->corners[i].Y1 * scale * yres);
++	y2 = _TIFFClampDoubleToUInt32(crop->corners[i].Y2 * scale * yres);
+         }
+       else
+         {
+-	x1 = (uint32_t) (crop->corners[i].X1);
+-	x2 = (uint32_t) (crop->corners[i].X2);
+-	y1 = (uint32_t) (crop->corners[i].Y1);
+-	y2 = (uint32_t) (crop->corners[i].Y2);
++	x1 = _TIFFClampDoubleToUInt32(crop->corners[i].X1);
++	x2 = _TIFFClampDoubleToUInt32(crop->corners[i].X2);
++	y1 = _TIFFClampDoubleToUInt32(crop->corners[i].Y1);
++	y2 = _TIFFClampDoubleToUInt32(crop->corners[i].Y2);
+ 	}
+       /* a) Region needs to be within image sizes 0.. width-1; 0..length-1 
+        * b) Corners are expected to be submitted as top-left to bottom-right.
+@@ -5357,17 +5357,17 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+     {
+     if (crop->res_unit != RESUNIT_INCH && crop->res_unit != RESUNIT_CENTIMETER)
+       { /* User has specified pixels as reference unit */
+-      tmargin = (uint32_t)(crop->margins[0]);
+-      lmargin = (uint32_t)(crop->margins[1]);
+-      bmargin = (uint32_t)(crop->margins[2]);
+-      rmargin = (uint32_t)(crop->margins[3]);
++      tmargin = _TIFFClampDoubleToUInt32(crop->margins[0]);
++      lmargin = _TIFFClampDoubleToUInt32(crop->margins[1]);
++      bmargin = _TIFFClampDoubleToUInt32(crop->margins[2]);
++      rmargin = _TIFFClampDoubleToUInt32(crop->margins[3]);
+       }
+     else
+       { /* inches or centimeters specified */
+-      tmargin = (uint32_t)(crop->margins[0] * scale * yres);
+-      lmargin = (uint32_t)(crop->margins[1] * scale * xres);
+-      bmargin = (uint32_t)(crop->margins[2] * scale * yres);
+-      rmargin = (uint32_t)(crop->margins[3] * scale * xres);
++      tmargin = _TIFFClampDoubleToUInt32(crop->margins[0] * scale * yres);
++      lmargin = _TIFFClampDoubleToUInt32(crop->margins[1] * scale * xres);
++      bmargin = _TIFFClampDoubleToUInt32(crop->margins[2] * scale * yres);
++      rmargin = _TIFFClampDoubleToUInt32(crop->margins[3] * scale * xres);
+       }
+ 
+     if ((lmargin + rmargin) > image->width)
+@@ -5397,24 +5397,24 @@ computeInputPixelOffsets(struct crop_mask *crop, struct image_data *image,
+   if (crop->res_unit != RESUNIT_INCH && crop->res_unit != RESUNIT_CENTIMETER)
+     {
+     if (crop->crop_mode & CROP_WIDTH)
+-      width = (uint32_t)crop->width;
++      width = _TIFFClampDoubleToUInt32(crop->width);
+     else
+       width = image->width - lmargin - rmargin;
+ 
+     if (crop->crop_mode & CROP_LENGTH)
+-      length  = (uint32_t)crop->length;
++      length  = _TIFFClampDoubleToUInt32(crop->length);
+     else
+       length = image->length - tmargin - bmargin;
+     }
+   else
+     {
+     if (crop->crop_mode & CROP_WIDTH)
+-      width = (uint32_t)(crop->width * scale * image->xres);
++      width = _TIFFClampDoubleToUInt32(crop->width * scale * image->xres);
+     else
+       width = image->width - lmargin - rmargin;
+ 
+     if (crop->crop_mode & CROP_LENGTH)
+-      length  = (uint32_t)(crop->length * scale * image->yres);
++      length  = _TIFFClampDoubleToUInt32(crop->length * scale * image->yres);
+     else
+       length = image->length - tmargin - bmargin;
+     }
+@@ -5868,13 +5868,13 @@ computeOutputPixelOffsets (struct crop_mask *crop, struct image_data *image,
+     {
+     if (page->res_unit == RESUNIT_INCH || page->res_unit == RESUNIT_CENTIMETER)
+       { /* inches or centimeters specified */
+-      hmargin = (uint32_t)(page->hmargin * scale * page->hres * ((image->bps + 7) / 8));
+-      vmargin = (uint32_t)(page->vmargin * scale * page->vres * ((image->bps + 7) / 8));
++      hmargin = _TIFFClampDoubleToUInt32(page->hmargin * scale * page->hres * ((image->bps + 7) / 8));
++      vmargin = _TIFFClampDoubleToUInt32(page->vmargin * scale * page->vres * ((image->bps + 7) / 8));
+       }
+     else
+       { /* Otherwise user has specified pixels as reference unit */
+-      hmargin = (uint32_t)(page->hmargin * scale * ((image->bps + 7) / 8));
+-      vmargin = (uint32_t)(page->vmargin * scale * ((image->bps + 7) / 8));
++      hmargin = _TIFFClampDoubleToUInt32(page->hmargin * scale * ((image->bps + 7) / 8));
++      vmargin = _TIFFClampDoubleToUInt32(page->vmargin * scale * ((image->bps + 7) / 8));
+       }
+ 
+     if ((hmargin * 2.0) > (pwidth * page->hres))
+@@ -5912,13 +5912,13 @@ computeOutputPixelOffsets (struct crop_mask *crop, struct image_data *image,
+     {
+     if (page->mode & PAGE_MODE_PAPERSIZE )
+       {
+-      owidth  = (uint32_t)((pwidth * page->hres) - (hmargin * 2));
+-      olength = (uint32_t)((plength * page->vres) - (vmargin * 2));
++      owidth  = _TIFFClampDoubleToUInt32((pwidth * page->hres) - (hmargin * 2));
++      olength = _TIFFClampDoubleToUInt32((plength * page->vres) - (vmargin * 2));
+       }
+     else
+       {
+-      owidth = (uint32_t)(iwidth - (hmargin * 2 * page->hres));
+-      olength = (uint32_t)(ilength - (vmargin * 2 * page->vres));
++      owidth = _TIFFClampDoubleToUInt32(iwidth - (hmargin * 2 * page->hres));
++      olength = _TIFFClampDoubleToUInt32(ilength - (vmargin * 2 * page->vres));
+       }
+     }
+ 
+@@ -5927,6 +5927,12 @@ computeOutputPixelOffsets (struct crop_mask *crop, struct image_data *image,
+   if (olength > ilength)
+     olength = ilength;
+ 
++  if (owidth == 0 || olength == 0)
++  {
++    TIFFError("computeOutputPixelOffsets", "Integer overflow when calculating the number of pages");
++    exit(EXIT_FAILURE);
++  }
++
+   /* Compute the number of pages required for Portrait or Landscape */
+   switch (page->orient)
+     {
+-- 
+2.25.1
+


### PR DESCRIPTION
The following issues are fixed

[CVE-2022-2058, BDSA-2022-1819](https://gitlab.com/libtiff/libtiff/-/issues/428)
[CVE-2022-2057, BDSA-2022-1818](https://gitlab.com/libtiff/libtiff/-/issues/427)
[CVE-2022-2056, BDSA-2022-1812](https://gitlab.com/libtiff/libtiff/-/issues/415)

by application of the MR: https://gitlab.com/libtiff/libtiff/-/merge_requests/346

Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>