### PR TITLE
Update protobuf to v21.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,8 +130,8 @@ The repository consists mostly of externally hosted subrepositories:
 .. _protobuf: https://github.com/protocolbuffers/protobuf/
 .. |protobuflic| replace:: BSD-3 license
 .. _protobuflic: https://github.com/protocolbuffers/protobuf/blob/master/LICENSE
-.. |protobufver| replace:: 21.5
-.. _protobufver: https://github.com/protocolbuffers/protobuf/releases/tag/v21.5
+.. |protobufver| replace:: 21.7
+.. _protobufver: https://github.com/protocolbuffers/protobuf/releases/tag/v21.7
 
 .. _CMake: https://github.com/Kitware/CMake/
 .. |CMakelic| replace:: BSD-3 license


### PR DESCRIPTION
We update form 21.5 to 21.7.
The updated version addresses (in fact v21.6 already does): CVE-2022-1941.

Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>