### PR TITLE
Fix libtiff CVE-2022-3970

### DIFF
--- a/build_scripts/build_libtiff.sh
+++ b/build_scripts/build_libtiff.sh
@@ -24,6 +24,7 @@ patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-2953-0002.patch
 patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-3597-3626-3627.patch
 patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-3599.patch
 patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-3570-3598.patch
+patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2022-3970.patch
 
 mkdir -p build
 cd build

--- a/patches/libtiff-CVE-2022-3970.patch
+++ b/patches/libtiff-CVE-2022-3970.patch
@@ -1,0 +1,38 @@
+From 227500897dfb07fb7d27f7aa570050e62617e3be Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Tue, 8 Nov 2022 15:16:58 +0100
+Subject: [PATCH] TIFFReadRGBATileExt(): fix (unsigned) integer overflow on
+ strips/tiles > 2 GB
+
+Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53137
+---
+ libtiff/tif_getimage.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libtiff/tif_getimage.c b/libtiff/tif_getimage.c
+index a4d0c1d6..60b94d8e 100644
+--- a/libtiff/tif_getimage.c
++++ b/libtiff/tif_getimage.c
+@@ -3016,15 +3016,15 @@ TIFFReadRGBATileExt(TIFF* tif, uint32_t col, uint32_t row, uint32_t * raster, in
+         return( ok );
+ 
+     for( i_row = 0; i_row < read_ysize; i_row++ ) {
+-        memmove( raster + (tile_ysize - i_row - 1) * tile_xsize,
+-                 raster + (read_ysize - i_row - 1) * read_xsize,
++        memmove( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize,
++                 raster + (size_t)(read_ysize - i_row - 1) * read_xsize,
+                  read_xsize * sizeof(uint32_t) );
+-        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize+read_xsize,
++        _TIFFmemset( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize+read_xsize,
+                      0, sizeof(uint32_t) * (tile_xsize - read_xsize) );
+     }
+ 
+     for( i_row = read_ysize; i_row < tile_ysize; i_row++ ) {
+-        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize,
++        _TIFFmemset( raster + (size_t)(tile_ysize - i_row - 1) * tile_xsize,
+                      0, sizeof(uint32_t) * tile_xsize );
+     }
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Applying https://gitlab.com/libtiff/libtiff/-/commit/227500897dfb07fb7d27f7aa570050e62617e3be in the build to address BDSA-2022-3210/CVE-2022-3970.

Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>