### PR TITLE
Patch FFmpeg for CVE-2022-3965, CVE-2022-3964

### DIFF
--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -17,6 +17,8 @@
 # For a snapshot of the code, see the README.rst
 if [ ${WITH_FFMPEG} -gt 0 ]; then
     pushd third_party/FFmpeg
+    patch -p1 < ${ROOT_DIR}/patches/FFmpeg-CVE-2022-3965.patch
+    patch -p1 < ${ROOT_DIR}/patches/FFmpeg-CVE-2022-3964.patch
     ./configure \
         --prefix=${INSTALL_PREFIX} \
         --disable-static \

--- a/patches/FFmpeg-CVE-2022-3964.patch
+++ b/patches/FFmpeg-CVE-2022-3964.patch
@@ -1,0 +1,85 @@
+From 92f9b28ed84a77138105475beba16c146bdaf984 Mon Sep 17 00:00:00 2001
+From: Paul B Mahol <onemda@gmail.com>
+Date: Sat, 12 Nov 2022 16:12:00 +0100
+Subject: [PATCH] avcodec/rpzaenc: stop accessing out of bounds frame
+
+---
+ libavcodec/rpzaenc.c | 22 +++++++++++++++-------
+ 1 file changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/libavcodec/rpzaenc.c b/libavcodec/rpzaenc.c
+index d710eb4f82..4ced9523e2 100644
+--- a/libavcodec/rpzaenc.c
++++ b/libavcodec/rpzaenc.c
+@@ -205,7 +205,7 @@ static void get_max_component_diff(const BlockInfo *bi, const uint16_t *block_pt
+
+     // loop thru and compare pixels
+     for (y = 0; y < bi->block_height; y++) {
+-        for (x = 0; x < bi->block_width; x++){
++        for (x = 0; x < bi->block_width; x++) {
+             // TODO:  optimize
+             min_r = FFMIN(R(block_ptr[x]), min_r);
+             min_g = FFMIN(G(block_ptr[x]), min_g);
+@@ -278,7 +278,7 @@ static int leastsquares(const uint16_t *block_ptr, const BlockInfo *bi,
+         return -1;
+
+     for (i = 0; i < bi->block_height; i++) {
+-        for (j = 0; j < bi->block_width; j++){
++        for (j = 0; j < bi->block_width; j++) {
+             x = GET_CHAN(block_ptr[j], xchannel);
+             y = GET_CHAN(block_ptr[j], ychannel);
+             sumx += x;
+@@ -325,7 +325,7 @@ static int calc_lsq_max_fit_error(const uint16_t *block_ptr, const BlockInfo *bi
+     int max_err = 0;
+
+     for (i = 0; i < bi->block_height; i++) {
+-        for (j = 0; j < bi->block_width; j++){
++        for (j = 0; j < bi->block_width; j++) {
+             int x_inc, lin_y, lin_x;
+             x = GET_CHAN(block_ptr[j], xchannel);
+             y = GET_CHAN(block_ptr[j], ychannel);
+@@ -420,7 +420,9 @@ static void update_block_in_prev_frame(const uint16_t *src_pixels,
+                                        uint16_t *dest_pixels,
+                                        const BlockInfo *bi, int block_counter)
+ {
+-    for (int y = 0; y < 4; y++) {
++    const int y_size = FFMIN(4, bi->image_height - bi->row * 4);
++
++    for (int y = 0; y < y_size; y++) {
+         memcpy(dest_pixels, src_pixels, 8);
+         dest_pixels += bi->rowstride;
+         src_pixels += bi->rowstride;
+@@ -730,14 +732,15 @@ post_skip :
+
+             if (err > s->sixteen_color_thresh) { // DO SIXTEEN COLOR BLOCK
+                 uint16_t *row_ptr;
+-                int rgb555;
++                int y_size, rgb555;
+
+                 block_offset = get_block_info(&bi, block_counter);
+
+                 row_ptr = &src_pixels[block_offset];
++                y_size = FFMIN(4, bi.image_height - bi.row * 4);
+
+-                for (int y = 0; y < 4; y++) {
+-                    for (int x = 0; x < 4; x++){
++                for (int y = 0; y < y_size; y++) {
++                    for (int x = 0; x < 4; x++) {
+                         rgb555 = row_ptr[x] & ~0x8000;
+
+                         put_bits(&s->pb, 16, rgb555);
+@@ -745,6 +748,11 @@ post_skip :
+                     row_ptr += bi.rowstride;
+                 }
+
++                for (int y = y_size; y < 4; y++) {
++                    for (int x = 0; x < 4; x++)
++                        put_bits(&s->pb, 16, 0);
++                }
++
+                 block_counter++;
+             } else { // FOUR COLOR BLOCK
+                 block_counter += encode_four_color_block(min_color, max_color,
+--
+2.25.1
+

--- a/patches/FFmpeg-CVE-2022-3965.patch
+++ b/patches/FFmpeg-CVE-2022-3965.patch
@@ -1,0 +1,104 @@
+From 13c13109759090b7f7182480d075e13b36ed8edd Mon Sep 17 00:00:00 2001
+From: Paul B Mahol <onemda@gmail.com>
+Date: Sat, 12 Nov 2022 15:19:21 +0100
+Subject: [PATCH] avcodec/smcenc: stop accessing out of bounds frame
+
+---
+ libavcodec/smcenc.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/libavcodec/smcenc.c b/libavcodec/smcenc.c
+index f3d26a4e8d..33549b8ab4 100644
+--- a/libavcodec/smcenc.c
++++ b/libavcodec/smcenc.c
+@@ -61,6 +61,7 @@ typedef struct SMCContext {
+         { \
+             row_ptr += stride * 4; \
+             pixel_ptr = row_ptr; \
++            cur_y += 4; \
+         } \
+     } \
+ }
+@@ -117,6 +118,7 @@ static void smc_encode_stream(SMCContext *s, const AVFrame *frame,
+     const uint8_t *prev_pixels = (const uint8_t *)s->prev_frame->data[0];
+     uint8_t *distinct_values = s->distinct_values;
+     const uint8_t *pixel_ptr, *row_ptr;
++    const int height = frame->height;
+     const int width = frame->width;
+     uint8_t block_values[16];
+     int block_counter = 0;
+@@ -125,13 +127,14 @@ static void smc_encode_stream(SMCContext *s, const AVFrame *frame,
+     int color_octet_index = 0;
+     int color_table_index;  /* indexes to color pair, quad, or octet tables */
+     int total_blocks;
++    int cur_y = 0;
+ 
+     memset(s->color_pairs, 0, sizeof(s->color_pairs));
+     memset(s->color_quads, 0, sizeof(s->color_quads));
+     memset(s->color_octets, 0, sizeof(s->color_octets));
+ 
+     /* Number of 4x4 blocks in frame. */
+-    total_blocks = ((frame->width + 3) / 4) * ((frame->height + 3) / 4);
++    total_blocks = ((width + 3) / 4) * ((height + 3) / 4);
+ 
+     pixel_ptr = row_ptr = src_pixels;
+ 
+@@ -145,11 +148,13 @@ static void smc_encode_stream(SMCContext *s, const AVFrame *frame,
+         int cache_index;
+         int distinct = 0;
+         int blocks = 0;
++        int frame_y = cur_y;
+ 
+         while (prev_pixels && s->key_frame == 0 && block_counter + inter_skip_blocks < total_blocks) {
++            const int y_size = FFMIN(4, height - cur_y);
+             int compare = 0;
+ 
+-            for (int y = 0; y < 4; y++) {
++            for (int y = 0; y < y_size; y++) {
+                 const ptrdiff_t offset = pixel_ptr - src_pixels;
+                 const uint8_t *prev_pixel_ptr = prev_pixels + offset;
+ 
+@@ -170,8 +175,10 @@ static void smc_encode_stream(SMCContext *s, const AVFrame *frame,
+ 
+         pixel_ptr = xpixel_ptr;
+         row_ptr = xrow_ptr;
++        cur_y = frame_y;
+ 
+         while (block_counter > 0 && block_counter + intra_skip_blocks < total_blocks) {
++            const int y_size = FFMIN(4, height - cur_y);
+             const ptrdiff_t offset = pixel_ptr - src_pixels;
+             const int sy = offset / stride;
+             const int sx = offset % stride;
+@@ -180,7 +187,7 @@ static void smc_encode_stream(SMCContext *s, const AVFrame *frame,
+             const uint8_t *old_pixel_ptr = src_pixels + nx + ny * stride;
+             int compare = 0;
+ 
+-            for (int y = 0; y < 4; y++) {
++            for (int y = 0; y < y_size; y++) {
+                 compare |= memcmp(old_pixel_ptr + y * stride, pixel_ptr + y * stride, 4);
+                 if (compare)
+                     break;
+@@ -197,9 +204,11 @@ static void smc_encode_stream(SMCContext *s, const AVFrame *frame,
+ 
+         pixel_ptr = xpixel_ptr;
+         row_ptr = xrow_ptr;
++        cur_y = frame_y;
+ 
+         while (block_counter + coded_blocks < total_blocks && coded_blocks < 256) {
+-            for (int y = 0; y < 4; y++)
++            const int y_size = FFMIN(4, height - cur_y);
++            for (int y = 0; y < y_size; y++)
+                 memcpy(block_values + y * 4, pixel_ptr + y * stride, 4);
+ 
+             qsort(block_values, 16, sizeof(block_values[0]), smc_cmp_values);
+@@ -224,6 +233,7 @@ static void smc_encode_stream(SMCContext *s, const AVFrame *frame,
+ 
+         pixel_ptr = xpixel_ptr;
+         row_ptr = xrow_ptr;
++        cur_y = frame_y;
+ 
+         blocks = coded_blocks;
+         distinct = coded_distinct;
+-- 
+2.25.1
+


### PR DESCRIPTION
Following patches are applied:
  * https://github.com/FFmpeg/FFmpeg/commit/13c13109759090b7f7182480d075e13b36ed8edd for CVE-2022-3965
  * https://github.com/FFmpeg/FFmpeg/commit/92f9b28ed84a77138105475beba16c146bdaf984 for CVE-2022-3964

Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>