### PR TITLE
Patch OCV's libwebp for CVE-2023-1999, update OCV to 4.8.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,8 +96,8 @@ The repository consists mostly of externally hosted subrepositories:
 .. _opencv: https://github.com/opencv/opencv/
 .. |opencvlic| replace:: Apache License 2.0
 .. _opencvlic: https://github.com/opencv/opencv/blob/master/LICENSE
-.. |opencvver| replace:: 4.7.0
-.. _opencvver: https://github.com/opencv/opencv/releases/tag/4.7.0
+.. |opencvver| replace:: 4.8.0
+.. _opencvver: https://github.com/opencv/opencv/releases/tag/4.8.0
 
 .. _openjpeg: https://github.com/uclouvain/openjpeg
 .. |openjpeglic| replace:: BSD-2 license

--- a/build_scripts/build_opencv.sh
+++ b/build_scripts/build_opencv.sh
@@ -16,6 +16,9 @@
 
 # OpenCV
 pushd third_party/opencv
+pushd 3rdparty/libwebp
+patch -p1 < ${ROOT_DIR}/patches/opencv-libwebp-CVE-2023-1999.patch
+popd
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=RELEASE \

--- a/patches/opencv-libwebp-CVE-2023-1999.patch
+++ b/patches/opencv-libwebp-CVE-2023-1999.patch
@@ -1,0 +1,55 @@
+From a486d800b60d0af4cc0836bf7ed8f21e12974129 Mon Sep 17 00:00:00 2001
+From: James Zern <jzern@google.com>
+Date: Wed, 22 Feb 2023 22:15:47 -0800
+Subject: [PATCH] EncodeAlphaInternal: clear result->bw on error
+
+This avoids a double free should the function fail prior to
+VP8BitWriterInit() and a previous trial result's buffer carried over.
+Previously in ApplyFiltersAndEncode() trial.bw (with a previous
+iteration's buffer) would be freed, followed by best.bw pointing to the
+same buffer.
+
+Since:
+187d379d add a fallback to ALPHA_NO_COMPRESSION
+
+In addition, check the return value of VP8BitWriterInit() in this
+function.
+
+Bug: webp:603
+Change-Id: Ic258381ee26c8c16bc211d157c8153831c8c6910
+---
+ src/enc/alpha_enc.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/enc/alpha_enc.c b/src/enc/alpha_enc.c
+index f7c02690..7d205586 100644
+--- a/src/enc/alpha_enc.c
++++ b/src/enc/alpha_enc.c
+@@ -13,6 +13,7 @@
+ 
+ #include <assert.h>
+ #include <stdlib.h>
++#include <string.h>
+ 
+ #include "src/enc/vp8i_enc.h"
+ #include "src/dsp/dsp.h"
+@@ -148,6 +149,7 @@ static int EncodeAlphaInternal(const uint8_t* const data, int width, int height,
+       }
+     } else {
+       VP8LBitWriterWipeOut(&tmp_bw);
++      memset(&result->bw, 0, sizeof(result->bw));
+       return 0;
+     }
+   }
+@@ -162,7 +164,7 @@ static int EncodeAlphaInternal(const uint8_t* const data, int width, int height,
+   header = method | (filter << 2);
+   if (reduce_levels) header |= ALPHA_PREPROCESSED_LEVELS << 4;
+ 
+-  VP8BitWriterInit(&result->bw, ALPHA_HEADER_LEN + output_size);
++  if (!VP8BitWriterInit(&result->bw, ALPHA_HEADER_LEN + output_size)) ok = 0;
+   ok = ok && VP8BitWriterAppend(&result->bw, &header, ALPHA_HEADER_LEN);
+   ok = ok && VP8BitWriterAppend(&result->bw, output, output_size);
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
This PR:
* updates the OCV version to the newest stable available (4.7.0 -> 4.8.0)
* patches the 3rd party dependecy of OCV, the libwebp for https://nvd.nist.gov/vuln/detail/CVE-2023-1999#range-9363233
   * the upstream OCV does not address the vulnerability at the moment
   * the libwebp is patched by applying a commit from the newest upstream libwebp repo https://chromium.googlesource.com/webm/libwebp/+/e1adea50ed0113414449d890761e0cb6d8a0cec2/NEWS
   * namely the https://chromium.googlesource.com/webm/libwebp/+/a486d800b60d0af4cc0836bf7ed8f21e12974129%5E%21/#F0