### PR TITLE
Compile CFITSIO in reentrant mode

### DIFF
--- a/build_scripts/build_cfitsio.sh
+++ b/build_scripts/build_cfitsio.sh
@@ -32,7 +32,7 @@ fi
 echo "set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")" >> toolchain.cmake
 echo "set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")" >> toolchain.cmake
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake \
-      -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DUSE_CURL=OFF \
+      -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DUSE_CURL=OFF -DUSE_PTHREADS=ON \
       ..
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 make install


### PR DESCRIPTION
This PR enables `USE_PTHREADS` option in CFITSIO build script. It builds the library in reentrant mode. See CFITSIO manual (https://heasarc.gsfc.nasa.gov/fitsio/c/c_user/node15.html) and linked DALI PR (https://github.com/NVIDIA/DALI/pull/5239) for more details.