### PR TITLE
Fix libtiff CVE-2023-6288

### DIFF
--- a/build_scripts/build_libtiff.sh
+++ b/build_scripts/build_libtiff.sh
@@ -17,6 +17,7 @@
 # libtiff
 pushd third_party/libtiff
 patch -p1 < ${ROOT_DIR}/patches/0001-Fix-wget-complaing-about-expired-git.savannah.gnu.or.patch
+patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2023-6228.patch
 patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2023-6277.patch
 
 mkdir -p build

--- a/patches/libtiff-CVE-2023-6228.patch
+++ b/patches/libtiff-CVE-2023-6228.patch
@@ -1,0 +1,27 @@
+From 1e7d217a323eac701b134afc4ae39b6bdfdbc96a Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Sat, 9 Sep 2023 15:45:47 +0200
+Subject: [PATCH] Check also if codec of input image is available,
+ independently from codec check of output image and return with error if not.
+ Fixes #606.
+
+---
+ tools/tiffcp.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tools/tiffcp.c b/tools/tiffcp.c
+index aff06260..2628bdbb 100644
+--- a/tools/tiffcp.c
++++ b/tools/tiffcp.c
+@@ -846,6 +846,8 @@ static int tiffcp(TIFF *in, TIFF *out)
+     if (!TIFFIsCODECConfigured(compression))
+         return FALSE;
+     TIFFGetFieldDefaulted(in, TIFFTAG_COMPRESSION, &input_compression);
++    if (!TIFFIsCODECConfigured(input_compression))
++        return FALSE;
+     TIFFGetFieldDefaulted(in, TIFFTAG_PHOTOMETRIC, &input_photometric);
+     if (input_compression == COMPRESSION_JPEG)
+     {
+-- 
+2.25.1
+


### PR DESCRIPTION
This PR applies patch from the upstream libtiff repostiory that fixes CVE-2023-6228