### PR TITLE
Patch libtiff for CVE-2023-52356

### DIFF
--- a/build_scripts/build_libtiff.sh
+++ b/build_scripts/build_libtiff.sh
@@ -19,6 +19,7 @@ pushd third_party/libtiff
 patch -p1 < ${ROOT_DIR}/patches/0001-Fix-wget-complaing-about-expired-git.savannah.gnu.or.patch
 patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2023-6228.patch
 patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2023-6277.patch
+patch -p1 < ${ROOT_DIR}/patches/libtiff-CVE-2023-52356.patch
 
 mkdir -p build
 cd build

--- a/patches/libtiff-CVE-2023-52356.patch
+++ b/patches/libtiff-CVE-2023-52356.patch
@@ -1,0 +1,46 @@
+From 51558511bdbbcffdce534db21dbaf5d54b31638a Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Tue, 31 Oct 2023 15:58:41 +0100
+Subject: [PATCH] TIFFReadRGBAStrip/TIFFReadRGBATile: add more validation of
+ col/row (fixes #622)
+
+---
+ libtiff/tif_getimage.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/libtiff/tif_getimage.c b/libtiff/tif_getimage.c
+index 41f7dfd7..6fee35db 100644
+--- a/libtiff/tif_getimage.c
++++ b/libtiff/tif_getimage.c
+@@ -3224,6 +3224,13 @@ int TIFFReadRGBAStripExt(TIFF *tif, uint32_t row, uint32_t *raster,
+     if (TIFFRGBAImageOK(tif, emsg) &&
+         TIFFRGBAImageBegin(&img, tif, stop_on_error, emsg))
+     {
++        if (row >= img.height)
++        {
++            TIFFErrorExtR(tif, TIFFFileName(tif),
++                          "Invalid row passed to TIFFReadRGBAStrip().");
++            TIFFRGBAImageEnd(&img);
++            return (0);
++        }
+ 
+         img.row_offset = row;
+         img.col_offset = 0;
+@@ -3301,6 +3308,14 @@ int TIFFReadRGBATileExt(TIFF *tif, uint32_t col, uint32_t row, uint32_t *raster,
+         return (0);
+     }
+ 
++    if (col >= img.width || row >= img.height)
++    {
++        TIFFErrorExtR(tif, TIFFFileName(tif),
++                      "Invalid row/col passed to TIFFReadRGBATile().");
++        TIFFRGBAImageEnd(&img);
++        return (0);
++    }
++
+     /*
+      * The TIFFRGBAImageGet() function doesn't allow us to get off the
+      * edge of the image, even to fill an otherwise valid tile.  So we
+-- 
+2.25.1
+


### PR DESCRIPTION
Apply a patch from upstream's main branch with the fix for the CVE-2023-52356.