### PR TITLE
Explictly disable (unused so far) lzma in the zstd, ffmpeg, libtiff

### DIFF
--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -49,7 +49,8 @@ if [ ${WITH_FFMPEG} -gt 0 ]; then
         --disable-filters \
         --disable-bsfs \
         --disable-decoder=ipu \
-        --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb,mpeg4_unpack_bframes
+        --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb,mpeg4_unpack_bframes \
+        --disable-lzma
     # adds | sed 's/\(.*{\)/DALI_\1/' | to the version file generation command - it prepends "DALI_" to the symbol version
     sed -i 's/\$\$(M)sed '\''s\/MAJOR\/\$(lib$(NAME)_VERSION_MAJOR)\/'\'' \$\$< | \$(VERSION_SCRIPT_POSTPROCESS_CMD) > \$\$\@/\$\$(M)sed '\''s\/MAJOR\/\$(lib$(NAME)_VERSION_MAJOR)\/'\'' \$\$< | sed '\''s\/\\(\.*{\\)\/DALI_\\1\/'\'' | \$(VERSION_SCRIPT_POSTPROCESS_CMD) > \$\$\@/' ffbuild/library.mak
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)"

--- a/build_scripts/build_libtiff.sh
+++ b/build_scripts/build_libtiff.sh
@@ -38,7 +38,7 @@ echo "set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")" >> toolchain.cmake
 echo "set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")" >> toolchain.cmake
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake \
       -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
-      -Djbig=OFF \
+      -Djbig=OFF -Dlzma=OFF \
       ..
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 make install

--- a/build_scripts/build_zstd.sh
+++ b/build_scripts/build_zstd.sh
@@ -21,5 +21,5 @@ pushd third_party/zstd
    CC=${CC_COMP} \
    CXX=${CXX_COMP} \
    prefix=${INSTALL_PREFIX} \
-make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install 2>&1 >/dev/null
+make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 popd

--- a/build_scripts/build_zstd.sh
+++ b/build_scripts/build_zstd.sh
@@ -21,5 +21,5 @@ pushd third_party/zstd
    CC=${CC_COMP} \
    CXX=${CXX_COMP} \
    prefix=${INSTALL_PREFIX} \
-make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
+make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install HAVE_LZMA=0
 popd


### PR DESCRIPTION
Disable the lzma explicilty. We did not use the lzma (as it is absent in build container), so it should be no-op from the resulting binaries perspecitve.

Show the log of the zstd lib build.