### PR TITLE
Harden dependency build script inputs

### DIFF
--- a/build_scripts/build_aws-sdk-cpp.sh
+++ b/build_scripts/build_aws-sdk-cpp.sh
@@ -15,6 +15,21 @@
 # limitations under the License.
 
 export ROOT_DIR=$(pwd)
+# Validate before use
+if [[ ! "$CC_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CC_COMP contains invalid characters" >&2
+  exit 1
+fi
+# Validate before use
+if [[ ! "$CXX_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CXX_COMP contains invalid characters" >&2
+  exit 1
+fi
+# Validate before use
+if [[ ! "$CMAKE_TARGET_ARCH" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CMAKE_TARGET_ARCH contains invalid characters" >&2
+  exit 1
+fi
 
 mkdir -p ${ROOT_DIR}/third_party/openssl/build
 mkdir -p ${ROOT_DIR}/third_party/curl/build

--- a/build_scripts/build_opencv.sh
+++ b/build_scripts/build_opencv.sh
@@ -18,9 +18,19 @@
 pushd third_party/opencv
 mkdir -p build
 cd build
+# Validate no path traversal
+if [[ "$OPENCV_TOOLCHAIN_FILE" == *..* ]]; then
+  echo "ERROR: OPENCV_TOOLCHAIN_FILE must not contain '..'" >&2
+  exit 1
+fi
+TOOLCHAIN_PATH="$PWD/../platforms/${OPENCV_TOOLCHAIN_FILE}"
+if [[ ! -f "$TOOLCHAIN_PATH" ]]; then
+  echo "ERROR: Toolchain file not found: $TOOLCHAIN_PATH" >&2
+  exit 1
+fi
 cmake -DCMAKE_BUILD_TYPE=RELEASE \
       -DVIBRANTE_PDK:STRING=/ \
-      -DCMAKE_TOOLCHAIN_FILE=$PWD/../platforms/${OPENCV_TOOLCHAIN_FILE} \
+      -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_PATH} \
       -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
       -DBUILD_LIST=core,improc,imgcodecs \
       -DBUILD_SHARED_LIBS=OFF \

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -18,6 +18,23 @@
 pushd third_party/protobuf
 mkdir -p build
 cd build
+
+# Validate before use
+if [[ ! "$CC_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CC_COMP contains invalid characters" >&2
+  exit 1
+fi
+# Validate before use
+if [[ ! "$CXX_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CXX_COMP contains invalid characters" >&2
+  exit 1
+fi
+# Validate before use
+if [[ ! "$CMAKE_TARGET_ARCH" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CMAKE_TARGET_ARCH contains invalid characters" >&2
+  exit 1
+fi
+
 # Dprotobuf_FORCE_FETCH_DEPENDENCIES to ensure we don't use host dependencies
     CFLAGS="-fPIC" \
     CXXFLAGS="-fPIC -std=c++17" \

--- a/build_scripts/build_zlib.sh
+++ b/build_scripts/build_zlib.sh
@@ -18,6 +18,23 @@
 pushd third_party/zlib
 mkdir -p build
 cd build
+
+# Validate before use
+if [[ ! "$CC_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CC_COMP contains invalid characters" >&2
+  exit 1
+fi
+# Validate before use
+if [[ ! "$CXX_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CXX_COMP contains invalid characters" >&2
+  exit 1
+fi
+# Validate before use
+if [[ ! "$CMAKE_TARGET_ARCH" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  echo "ERROR: CMAKE_TARGET_ARCH contains invalid characters" >&2
+  exit 1
+fi
+
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
 echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
 echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake


### PR DESCRIPTION
Validate compiler, architecture, and OpenCV toolchain inputs before using them
to generate build commands or CMake toolchain files.

Reject unexpected characters in compiler and target architecture variables for
AWS SDK, Protobuf, and zlib builds. Prevent path traversal in the OpenCV
toolchain file selection and fail early when the resolved toolchain file is
missing.