### PR TITLE
fix: define ROOT_DIR before using it in libsndfile patch paths

### DIFF
--- a/build_scripts/build_libsnd.sh
+++ b/build_scripts/build_libsnd.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
+export ROOT_DIR=$(pwd)
 pushd third_party/libsndfile
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065.patch
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065-extra-overflow-fixes.patch


### PR DESCRIPTION
### Problem
fix: define ROOT_DIR before using it in libsndfile patch paths

### Fix
Replace:
```
# For a snapshot of the code, see the README.rst
pushd third_party/libsndfile
patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065.patch
```

with:
```
# For a snapshot of the code, see the README.rst
export ROOT_DIR=$(pwd)
pushd third_party/libsndfile
patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065.patch
```

### Files changed
- `build_scripts/build_libsnd.sh`