### PR TITLE
fix(build-lmdb): define ROOT_DIR before using it in lmdb (+1 more)

### DIFF
--- a/build_scripts/build_lmdb.sh
+++ b/build_scripts/build_lmdb.sh
@@ -15,9 +15,10 @@
 # limitations under the License.
 
 # LMDB
+export ROOT_DIR=$(pwd)
 pushd third_party/lmdb/libraries/liblmdb/
 patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
-    CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \
+    XCFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 prefix=${INSTALL_PREFIX} make install
 popd


### PR DESCRIPTION
This PR addresses 2 issues in `build_scripts/build_lmdb.sh`.

#### Fix 1
fix: define ROOT_DIR before using it in lmdb patch path

**Fix:** Replace:
```
# LMDB
pushd third_party/lmdb/libraries/liblmdb/
patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
```

with:
```
# LMDB
export ROOT_DIR=$(pwd)
pushd third_party/lmdb/libraries/liblmdb/
patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
```

#### Fix 2
fix: pass -fPIC via XCFLAGS so LMDB keeps thread/opt flags

**Fix:** Replace:
```
    CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \
make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
```

with:
```
    XCFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \
make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
```

### Files changed
- `build_scripts/build_lmdb.sh`