### PR TITLE
fix: use protobuf_PROTOC_EXE instead of WITH_PROTOC

### DIFF
--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -66,7 +66,7 @@ if [ "${CC_COMP}" != "gcc" ]; then
         -DBUILD_SHARED_LIBS=OFF \
         -Dprotobuf_BUILD_TESTS=OFF \
         -Dprotobuf_FORCE_FETCH_DEPENDENCIES=ON \
-        -DWITH_PROTOC=${HOST_INSTALL_PREFIX}/bin/protoc \
+        -Dprotobuf_PROTOC_EXE=${HOST_INSTALL_PREFIX}/bin/protoc \
         ..
   make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
   make install


### PR DESCRIPTION
### Problem
fix: use protobuf_PROTOC_EXE instead of WITH_PROTOC

### Fix
Replace:
```
-DWITH_PROTOC=${HOST_INSTALL_PREFIX}/bin/protoc
```

with:
```
-Dprotobuf_PROTOC_EXE=${HOST_INSTALL_PREFIX}/bin/protoc
```

### Files changed
- `build_scripts/build_protobuf.sh`