### PR TITLE
fix: cross-compile detection treats full-path gcc as cross compiler

### DIFF
--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -34,7 +34,17 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 make -j"${JOBS}"
 make install
 # only when cross compiling
-if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
+# A full-path native compiler (e.g. /usr/bin/gcc) must not be treated as
+# a cross compiler (the original bug): compare basenames. A cross
+# toolchain can also be exposed under a plain "gcc" name (e.g.
+# /opt/cross/bin/gcc), so additionally compare the compiler's target
+# architecture against the build host; when the compiler cannot be
+# queried, the basename check alone decides.
+CC_COMP_BASENAME=$(basename "${CC_COMP}")
+CC_COMP_TARGET_ARCH=$("${CC_COMP}" -dumpmachine 2>/dev/null | cut -d- -f1)
+if [[ -n ${CC_COMP:-} ]] && \
+   { [[ ${CC_COMP_BASENAME} != gcc ]] || \
+     [[ -n ${CC_COMP_TARGET_ARCH} && ${CC_COMP_TARGET_ARCH} != "$(uname -m)" ]]; }; then
   rm -rf *
   echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
   if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then


### PR DESCRIPTION
This PR fixes a script issue in `build_scripts/build_protobuf.sh`: cross-compile detection misclassifies gcc by name.

## Changes
- `build_scripts/build_protobuf.sh`: use the compiler basename and its `-dumpmachine` target architecture to decide whether a second target-arch protobuf build is needed.

## Details

Previously the build gate compared `CC_COMP` against the literal string `gcc`, which misclassified two cases: a full-path native compiler (e.g. `/usr/bin/gcc`) was treated as a cross compiler and triggered a bogus second target-arch rebuild, while a cross toolchain exposed under a plain `gcc` name (e.g. a wrapper earlier in `PATH`) was treated as native and skipped the target-arch build entirely.

The gate now compares the compiler's **basename** against `gcc` **and** its `-dumpmachine` target architecture against the build host (`uname -m`). Either signal marks the compiler as cross; when `-dumpmachine` cannot be queried the check falls back to the basename comparison alone. The empty-`CC_COMP` host-only guard introduced by #176 is preserved.

## Relation to #176

Complementary, not superseded — #176 validates the toolchain environment values before they are written into CMake files (and errors when a cross compiler lacks `CMAKE_TARGET_ARCH`); this fix corrects the classification gate that decides whether the second target-arch protobuf build runs at all. Rebased onto current `main` including those validation changes.

## Tests

No regression test is attached; the repository does not have a harness that exercises this build-script path. The decision logic was verified locally with a stub-compiler harness (full-path native gcc now builds host-only, cross wrappers named gcc now trigger the target-arch build, triplet-prefixed cross compilers and unset `CC_COMP` behave as before). Let me know if you want tests added for this fix or not.

## Contributor guidelines
- **DCO sign-off**: This commit includes a `Signed-off-by: andrewwhitecdw <andrewwhitecdw@users.noreply.github.com>` trailer.
