### PR TITLE
fix: Duplicated compiler-variable validation blocks

### DIFF
--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -19,23 +19,21 @@ pushd third_party/protobuf
 mkdir -p build
 cd build
 
+validate_alnum() {
+  local var_name=$1
+  local var_value=$2
+  if [[ ! "$var_value" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+    echo "ERROR: $var_name contains invalid characters" >&2
+    exit 1
+  fi
+}
+
 # Validate before use
 JOBS=$(nproc)
 
-if [[ ! "$CC_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CC_COMP contains invalid characters" >&2
-  exit 1
-fi
-# Validate before use
-if [[ ! "$CXX_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CXX_COMP contains invalid characters" >&2
-  exit 1
-fi
-# Validate before use
-if [[ ! "$CMAKE_TARGET_ARCH" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CMAKE_TARGET_ARCH contains invalid characters" >&2
-  exit 1
-fi
+validate_alnum CC_COMP "$CC_COMP"
+validate_alnum CXX_COMP "$CXX_COMP"
+validate_alnum CMAKE_TARGET_ARCH "$CMAKE_TARGET_ARCH"
 
 # Dprotobuf_FORCE_FETCH_DEPENDENCIES to ensure we don't use host dependencies
     CFLAGS="-fPIC" \


### PR DESCRIPTION
This PR fixes a script issue in `build_scripts/build_protobuf.sh`: duplicated compiler-variable validation blocks.

## Changes
- `build_scripts/build_protobuf.sh`: Extract the repeated `^[a-zA-Z0-9/_.+-]+$` validation for `CC_COMP`, `CXX_COMP`, and `CMAKE_TARGET_ARCH` into a single `validate_alnum` helper. Behavior and diagnostics are preserved.

## Details
See the Files changed tab for the exact diff.

## Tests
No regression test is attached; the repository does not have a harness that exercises this build-script path. Let me know if you want tests added for this fix or not.

## Contributor guidelines
- **DCO sign-off**: This commit includes a `Signed-off-by: Andrew White <andrewh@cdw.com>` trailer.