### PR TITLE
Patch FFmpeg 8.1.2

### DIFF
--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -17,6 +17,14 @@
 # For a snapshot of the code, see the README.rst
 if [ ${WITH_FFMPEG} -gt 0 ]; then
     pushd third_party/FFmpeg
+    patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-01-CVE-2026-66037-iamf-count-label.patch
+    patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-02-CVE-2026-64834-rtpdec-asf-infinite-loop.patch
+    patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-03-CVE-2026-64830-vobsub-stream-count.patch
+    patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-04-CVE-2026-64835-adx-channel-state.patch
+    patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-05-CVE-2026-66039-mace-decode-int-overflow.patch
+    patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-06-CVE-2026-66038-lcldec-heap-disclosure.patch
+    patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-07-CVE-2026-65703-tdsc-refframe-size-change.patch
+    patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-08-CVE-2026-65704-ty-ac3-size-underflow.patch
     ./configure \
         --prefix=${INSTALL_PREFIX} \
         --disable-static \

--- a/patches/ffmpeg/ffmpeg-01-CVE-2026-66037-iamf-count-label.patch
+++ b/patches/ffmpeg/ffmpeg-01-CVE-2026-66037-iamf-count-label.patch
@@ -1,0 +1,34 @@
+From 86708357d126af84c16f80d9c57335d1e8c845c5 Mon Sep 17 00:00:00 2001
+From: Michael Niedermayer <michael@niedermayer.cc>
+Date: Sun, 28 Jun 2026 22:05:28 +0200
+Subject: [PATCH] avformat/iamf_parse: check count_label against the available
+ bytes
+
+Fixes: unbounded allocation / denial of service
+Fixes: tP59h4cpaFyg
+Fixes: 4ee05182b7 (avformat: Immersive Audio Model and Formats demuxer)
+Found-by: Adrian Junge (vurlo)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavformat/iamf_parse.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libavformat/iamf_parse.c b/libavformat/iamf_parse.c
+index d74a8677d6..4c2df2c9e6 100644
+--- a/libavformat/iamf_parse.c
++++ b/libavformat/iamf_parse.c
+@@ -1009,6 +1009,11 @@ static int mix_presentation_obu(void *s, IAMFContext *c, AVIOContext *pb, int le
+     mix_presentation->cmix = mix;
+ 
+     mix_presentation->count_label = ffio_read_leb(pbc);
++    if (mix_presentation->count_label > len - avio_tell(pbc)) {
++        mix_presentation->count_label = 0;
++        ret = AVERROR_INVALIDDATA;
++        goto fail;
++    }
+     mix_presentation->language_label = av_calloc(mix_presentation->count_label,
+                                                  sizeof(*mix_presentation->language_label));
+     if (!mix_presentation->language_label) {
+-- 
+2.43.0
+

--- a/patches/ffmpeg/ffmpeg-02-CVE-2026-64834-rtpdec-asf-infinite-loop.patch
+++ b/patches/ffmpeg/ffmpeg-02-CVE-2026-64834-rtpdec-asf-infinite-loop.patch
@@ -1,0 +1,31 @@
+From 11d5f475be95d22d5f0692220cc772b116abc632 Mon Sep 17 00:00:00 2001
+From: Pavel Kohout <disclosure@aisle.com>
+Date: Tue, 30 Jun 2026 21:55:16 +0200
+Subject: [PATCH] avformat/rtpdec_asf: reject ASF objects smaller than their
+ header
+
+Fixes: infinite loop
+Fixes: MzWwJdpZF2Ls
+Fixes: c2f3eec445389d67afc8c699ba23915a20cae51c (Implement RTSP-MS/ASF packet parsing.)
+Found-by: Pavel Kohout (Aisle Research)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavformat/rtpdec_asf.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libavformat/rtpdec_asf.c b/libavformat/rtpdec_asf.c
+index b3b346f3cc..f7fa69e27f 100644
+--- a/libavformat/rtpdec_asf.c
++++ b/libavformat/rtpdec_asf.c
+@@ -56,6 +56,8 @@ static int rtp_asf_fix_header(uint8_t *buf, int len)
+         uint64_t chunksize = AV_RL64(p + sizeof(ff_asf_guid));
+         int skip = 6 * 8 + 3 * 4 + sizeof(ff_asf_guid) * 2;
+         if (memcmp(p, ff_asf_file_header, sizeof(ff_asf_guid))) {
++            if (chunksize < sizeof(ff_asf_guid) + 8)
++                return -1;
+             if (chunksize > end - p)
+                 return -1;
+             p += chunksize;
+-- 
+2.43.0
+

--- a/patches/ffmpeg/ffmpeg-03-CVE-2026-64830-vobsub-stream-count.patch
+++ b/patches/ffmpeg/ffmpeg-03-CVE-2026-64830-vobsub-stream-count.patch
@@ -1,0 +1,60 @@
+From dbd495f066a85ba96b17433f4306582aa37c3951 Mon Sep 17 00:00:00 2001
+From: Pavel Kohout <disclosure@aisle.com>
+Date: Mon, 29 Jun 2026 23:30:41 +0200
+Subject: [PATCH] avformat/vobsub: reuse subtitle streams and bound the stream
+ count
+
+Fixes: heap buffer overflow
+Fixes: lqaO5R1BaZGO
+Fixes: dbfe61100b (avformat/vobsub: fix several issues.)
+Found-by: Pavel Kohout (Aisle Research)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavformat/mpeg.c | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/libavformat/mpeg.c b/libavformat/mpeg.c
+index ff5ced8107..29abe329b9 100644
+--- a/libavformat/mpeg.c
++++ b/libavformat/mpeg.c
+@@ -841,6 +841,20 @@ static int vobsub_read_header(AVFormatContext *s)
+             }
+ 
+             if (!st || st->id != stream_id) {
++                st = NULL;
++                for (i = 0; i < s->nb_streams; i++) {
++                    if (s->streams[i]->id == stream_id) {
++                        st = s->streams[i];
++                        break;
++                    }
++                }
++            }
++            if (!st) {
++                if (s->nb_streams >= FF_ARRAY_ELEMS(vobsub->q)) {
++                    av_log(s, AV_LOG_ERROR, "Maximum number of subtitle streams reached\n");
++                    ret = AVERROR_INVALIDDATA;
++                    goto end;
++                }
+                 st = avformat_new_stream(s, NULL);
+                 if (!st) {
+                     ret = AVERROR(ENOMEM);
+@@ -865,14 +879,14 @@ static int vobsub_read_header(AVFormatContext *s)
+             timestamp = (hh*3600LL + mm*60LL + ss) * 1000LL + ms + delay;
+             timestamp = av_rescale_q(timestamp, av_make_q(1, 1000), st->time_base);
+ 
+-            sub = ff_subtitles_queue_insert(&vobsub->q[s->nb_streams - 1], "", 0, 0);
++            sub = ff_subtitles_queue_insert(&vobsub->q[st->index], "", 0, 0);
+             if (!sub) {
+                 ret = AVERROR(ENOMEM);
+                 goto end;
+             }
+             sub->pos = pos;
+             sub->pts = timestamp;
+-            sub->stream_index = s->nb_streams - 1;
++            sub->stream_index = st->index;
+ 
+         } else if (!strncmp(line, "alt:", 4)) {
+             const char *p = line + 4;
+-- 
+2.43.0
+

--- a/patches/ffmpeg/ffmpeg-04-CVE-2026-64835-adx-channel-state.patch
+++ b/patches/ffmpeg/ffmpeg-04-CVE-2026-64835-adx-channel-state.patch
@@ -1,0 +1,40 @@
+From 1836ef96846937a6cc2443698a693104f5c0b21e Mon Sep 17 00:00:00 2001
+From: Pavel Kohout <disclosure@aisle.com>
+Date: Mon, 29 Jun 2026 23:46:16 +0200
+Subject: [PATCH] avcodec/adx: sync decoder channel state on NEW_EXTRADATA
+
+Fixes: out of array access
+Fixes: heaNtmHvklpe
+Fixes: 92396cee602320c714713ca2d93b53684ad57000 (avformat: add CRI AAX demuxer)
+Found-by: Pavel Kohout (Aisle Research)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/adxdec.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libavcodec/adxdec.c b/libavcodec/adxdec.c
+index 019fc1a90d..a79ae430aa 100644
+--- a/libavcodec/adxdec.c
++++ b/libavcodec/adxdec.c
+@@ -173,6 +173,7 @@ static int adx_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+     new_extradata = av_packet_get_side_data(avpkt, AV_PKT_DATA_NEW_EXTRADATA,
+                                             &new_extradata_size);
+     if (new_extradata && new_extradata_size > 0) {
++        int old_channels = c->channels;
+         int header_size;
+         if ((ret = adx_decode_header(avctx, new_extradata,
+                                      new_extradata_size, &header_size,
+@@ -181,6 +182,10 @@ static int adx_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+             return AVERROR_INVALIDDATA;
+         }
+ 
++        c->channels      = avctx->ch_layout.nb_channels;
++        c->header_parsed = 1;
++        if (old_channels != c->channels)
++            memset(c->prev, 0, sizeof(c->prev));
+         c->eof = 0;
+     }
+ 
+-- 
+2.43.0
+

--- a/patches/ffmpeg/ffmpeg-05-CVE-2026-66039-mace-decode-int-overflow.patch
+++ b/patches/ffmpeg/ffmpeg-05-CVE-2026-66039-mace-decode-int-overflow.patch
@@ -1,0 +1,33 @@
+From aafb5c655edc76a753275c383ebb139feb032718 Mon Sep 17 00:00:00 2001
+From: Michael Niedermayer <michael@niedermayer.cc>
+Date: Mon, 29 Jun 2026 01:16:44 +0200
+Subject: [PATCH] avcodec/mace: reject sample counts that overflow int
+
+Fixes: heap buffer overflow
+Fixes: FmXBI2dbgvgD
+Fixes: 0eea212943544d40f99b05571aa7159d78667154 (Add avcodec_decode_audio4().)
+Found-by: Adrian Junge (vurlo)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/mace.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/libavcodec/mace.c b/libavcodec/mace.c
+index 299e5f5cfe..87e802684a 100644
+--- a/libavcodec/mace.c
++++ b/libavcodec/mace.c
+@@ -252,7 +252,10 @@ static int mace_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+     }
+ 
+     /* get output buffer */
+-    frame->nb_samples = 3 * (buf_size << (1 - is_mace3)) / channels;
++    int64_t nb_samples = 3 * ((int64_t)buf_size << (1 - is_mace3)) / channels;
++    if (nb_samples > INT_MAX)
++        return AVERROR_INVALIDDATA;
++    frame->nb_samples = nb_samples;
+     if ((ret = ff_get_buffer(avctx, frame, 0)) < 0)
+         return ret;
+     samples = (int16_t **)frame->extended_data;
+-- 
+2.43.0
+

--- a/patches/ffmpeg/ffmpeg-06-CVE-2026-66038-lcldec-heap-disclosure.patch
+++ b/patches/ffmpeg/ffmpeg-06-CVE-2026-66038-lcldec-heap-disclosure.patch
@@ -1,0 +1,45 @@
+From e7cbfd1c507b57a806a5825b87d609963e862c8c Mon Sep 17 00:00:00 2001
+From: Michael Niedermayer <michael@niedermayer.cc>
+Date: Sun, 28 Jun 2026 19:04:07 +0200
+Subject: [PATCH] avcodec/lcldec: zero the not-decoded tail to avoid heap
+ disclosure
+
+Fixes: use of uninitialized memory
+Fixes: CsNDKB1K1U0C
+Fixes: e2c3aa8e2b (avcodec/lcldec: More space for rgb24)
+Found-by: Adrian Junge (vurlo)
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavcodec/lcldec.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/libavcodec/lcldec.c b/libavcodec/lcldec.c
+index 29b1d85be3..5023243017 100644
+--- a/libavcodec/lcldec.c
++++ b/libavcodec/lcldec.c
+@@ -120,6 +120,9 @@ static unsigned int mszh_decomp(const unsigned char * srcptr, int srclen, unsign
+         }
+     }
+ 
++    if (destptr < destptr_end)
++        memset(destptr, 0, destptr_end - destptr);
++
+     return destptr - destptr_bak;
+ }
+ 
+@@ -153,8 +156,11 @@ static int zlib_decomp(AVCodecContext *avctx, const uint8_t *src, int src_len, i
+     if (expected != (unsigned int)zstream->total_out) {
+         av_log(avctx, AV_LOG_ERROR, "Decoded size differs (%d != %lu)\n",
+                expected, zstream->total_out);
+-        if (expected > (unsigned int)zstream->total_out)
++        if (expected > (unsigned int)zstream->total_out) {
++            memset(c->decomp_buf + offset + zstream->total_out, 0,
++                   c->decomp_size - offset - zstream->total_out);
+             return (unsigned int)zstream->total_out;
++        }
+         return AVERROR_UNKNOWN;
+     }
+     return zstream->total_out;
+-- 
+2.43.0
+

--- a/patches/ffmpeg/ffmpeg-07-CVE-2026-65703-tdsc-refframe-size-change.patch
+++ b/patches/ffmpeg/ffmpeg-07-CVE-2026-65703-tdsc-refframe-size-change.patch
@@ -1,0 +1,42 @@
+From fd3ee52fab34d98a95b787d0b5ff45685766200c Mon Sep 17 00:00:00 2001
+From: Cloud-LHY <security@clouditera.com>
+Date: Fri, 10 Jul 2026 04:07:04 +0200
+Subject: [PATCH] avcodec/tdsc: unref the reference frame before reallocating
+ on size change
+
+Fixes: out of array access
+Fixes: tdsc_poc/ffmpeg-tdsc-linesize-report/poc.avi / gen_poc.py
+Fixes: tdsc_resize_jpeg_oob.avi / tdsc-resize-stale-linesize-jpeg-oob-generate-poc.py
+Fixes: p9xG4xGf9P7H
+Fixes: HQL7a1WgTdHZ
+Found-by: Cloud-LHY / Clouditera Security, Z.ai Security, NSFOCUS
+Found-by: Adrian Junge (vurlo)
+---
+ libavcodec/tdsc.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/tdsc.c b/libavcodec/tdsc.c
+index ca9dd0f0a6..102b4ae966 100644
+--- a/libavcodec/tdsc.c
++++ b/libavcodec/tdsc.c
+@@ -485,11 +485,15 @@ static int tdsc_parse_tdsf(AVCodecContext *avctx, int number_tiles)
+             return ret;
+         init_refframe = 1;
+     }
+-    ctx->refframe->width  = ctx->width  = w;
+-    ctx->refframe->height = ctx->height = h;
++    ctx->width  = w;
++    ctx->height = h;
+ 
+     /* Allocate the reference frame if not already done or on size change */
+     if (init_refframe) {
++        av_frame_unref(ctx->refframe);
++        ctx->refframe->format = avctx->pix_fmt;
++        ctx->refframe->width  = w;
++        ctx->refframe->height = h;
+         ret = av_frame_get_buffer(ctx->refframe, 0);
+         if (ret < 0)
+             return ret;
+-- 
+2.43.0
+

--- a/patches/ffmpeg/ffmpeg-08-CVE-2026-65704-ty-ac3-size-underflow.patch
+++ b/patches/ffmpeg/ffmpeg-08-CVE-2026-65704-ty-ac3-size-underflow.patch
@@ -1,0 +1,30 @@
+From de771bd52774a52d45b0e2c82e56995a1ef40df7 Mon Sep 17 00:00:00 2001
+From: Michael Niedermayer <michael@niedermayer.cc>
+Date: Fri, 10 Jul 2026 04:07:35 +0200
+Subject: [PATCH] avformat/ty: don't let the Series2 AC3 trim underflow the
+ packet size
+
+Fixes: negative-size-param
+Fixes: ty-s2-ac3-negative-size-single-file.ffconcat / create_poc.py
+Fixes: g0qeE6KvrjZi
+Found-by: Adrian Junge (vurlo)
+---
+ libavformat/ty.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavformat/ty.c b/libavformat/ty.c
+index 9be027fcca..842d97038c 100644
+--- a/libavformat/ty.c
++++ b/libavformat/ty.c
+@@ -578,7 +578,7 @@ static int demux_audio(AVFormatContext *s, TyRecHdr *rec_hdr, AVPacket *pkt)
+         if (ty->audio_type == TIVO_AUDIO_AC3 &&
+                 ty->tivo_series == TIVO_SERIES2) {
+             if (ty->ac3_pkt_size + pkt->size > AC3_PKT_LENGTH) {
+-                pkt->size -= 2;
++                pkt->size -= FFMIN(pkt->size, 2);
+                 ty->ac3_pkt_size = 0;
+             } else {
+                 ty->ac3_pkt_size += pkt->size;
+-- 
+2.43.0
+


### PR DESCRIPTION
Applies upstream patches for the following CVEs:

* https://nvd.nist.gov/vuln/detail/CVE-2026-66037
* https://nvd.nist.gov/vuln/detail/CVE-2026-64834
* https://nvd.nist.gov/vuln/detail/CVE-2026-64830
* https://nvd.nist.gov/vuln/detail/CVE-2026-64835
* https://nvd.nist.gov/vuln/detail/CVE-2026-66039
* https://nvd.nist.gov/vuln/detail/CVE-2026-66038
* https://nvd.nist.gov/vuln/detail/CVE-2026-65703
* https://nvd.nist.gov/vuln/detail/CVE-2026-65704


