### PR TITLE
security: harden dependency build script inputs

### DIFF
--- a/build_scripts/build_aws-sdk-cpp.sh
+++ b/build_scripts/build_aws-sdk-cpp.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 
 mkdir -p ${ROOT_DIR}/third_party/openssl/build
 mkdir -p ${ROOT_DIR}/third_party/curl/build

--- a/build_scripts/build_aws-sdk-cpp.sh
+++ b/build_scripts/build_aws-sdk-cpp.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 
 mkdir -p ${ROOT_DIR}/third_party/openssl/build

--- a/build_scripts/build_aws-sdk-cpp.sh
+++ b/build_scripts/build_aws-sdk-cpp.sh
@@ -61,7 +61,8 @@ case "$CMAKE_TARGET_ARCH" in
     ;;
 esac
 CC="${CC_COMP}" CXX="${CXX_COMP}" CPPFLAGS="${CPPFLAGS:-}" \
-  CFLAGS="${CFLAGS:-} -fPIC -Wa,--noexecstack" LDFLAGS="${LDFLAGS:-}" \
+  CFLAGS="${CFLAGS:-} -fPIC -Wa,--noexecstack" \
+  CXXFLAGS="${CXXFLAGS:-} -fPIC -Wa,--noexecstack" LDFLAGS="${LDFLAGS:-}" \
   "${_CONFIGURATOR}" "${OPTS[@]}"
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 make install_sw install_ssldirs

--- a/build_scripts/build_aws-sdk-cpp.sh
+++ b/build_scripts/build_aws-sdk-cpp.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 
 mkdir -p ${ROOT_DIR}/third_party/openssl/build

--- a/build_scripts/build_aws-sdk-cpp.sh
+++ b/build_scripts/build_aws-sdk-cpp.sh
@@ -28,11 +28,17 @@ export DEPS_OPENSSLDIR=${ROOT_DIR}/third_party/aws-sdk-cpp/openssldir
 export TOOLCHAIN_FILE=${ROOT_DIR}/third_party/aws-sdk-cpp/toolchain.cmake
 
 echo "set(CMAKE_SYSTEM_NAME Linux)" > ${TOOLCHAIN_FILE}
-echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> ${TOOLCHAIN_FILE}
-echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> ${TOOLCHAIN_FILE}
-echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> ${TOOLCHAIN_FILE}
+if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> ${TOOLCHAIN_FILE}
+fi
+if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> ${TOOLCHAIN_FILE}
+fi
+if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> ${TOOLCHAIN_FILE}
+fi
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
     echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> ${TOOLCHAIN_FILE}
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> ${TOOLCHAIN_FILE}
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> ${TOOLCHAIN_FILE}
@@ -52,7 +58,8 @@ OPTS+=(--libdir=lib)
 OPTS+=(--prefix=${DEPS_PREFIX})
 OPTS+=(--openssldir=${DEPS_OPENSSLDIR})
 _CONFIGURATOR="./Configure"
-case "$CMAKE_TARGET_ARCH" in
+OPENSSL_TARGET_ARCH=${CMAKE_TARGET_ARCH:-$(uname -m)}
+case "$OPENSSL_TARGET_ARCH" in
   x86_64)
     OPTS+=(linux-x86_64)
     ;;

--- a/build_scripts/build_aws-sdk-cpp.sh
+++ b/build_scripts/build_aws-sdk-cpp.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=$(pwd)
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 # Validate before use
 if [[ ! "$CC_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
   echo "ERROR: CC_COMP contains invalid characters" >&2
@@ -74,8 +74,9 @@ case "$CMAKE_TARGET_ARCH" in
     OPTS+=(linux-aarch64)
     ;;
 esac
-CC=${CC_COMP} CXX=${CXX_COMP}" ${CPPFLAGS} ${CFLAGS}" \
-  ${_CONFIGURATOR} ${OPTS[@]} ${LDFLAGS}
+CC="${CC_COMP}" CXX="${CXX_COMP}" CPPFLAGS="${CPPFLAGS:-}" \
+  CFLAGS="${CFLAGS:-} -fPIC -Wa,--noexecstack" LDFLAGS="${LDFLAGS:-}" \
+  "${_CONFIGURATOR}" "${OPTS[@]}"
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 make install_sw install_ssldirs
 

--- a/build_scripts/build_aws-sdk-cpp.sh
+++ b/build_scripts/build_aws-sdk-cpp.sh
@@ -15,21 +15,7 @@
 # limitations under the License.
 
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
-# Validate before use
-if [[ ! "$CC_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CC_COMP contains invalid characters" >&2
-  exit 1
-fi
-# Validate before use
-if [[ ! "$CXX_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CXX_COMP contains invalid characters" >&2
-  exit 1
-fi
-# Validate before use
-if [[ ! "$CMAKE_TARGET_ARCH" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CMAKE_TARGET_ARCH contains invalid characters" >&2
-  exit 1
-fi
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 
 mkdir -p ${ROOT_DIR}/third_party/openssl/build
 mkdir -p ${ROOT_DIR}/third_party/curl/build

--- a/build_scripts/build_cfitsio.sh
+++ b/build_scripts/build_cfitsio.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # Cfitsio
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/cfitsio"
 mkdir -p build
 cd build

--- a/build_scripts/build_cfitsio.sh
+++ b/build_scripts/build_cfitsio.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # Cfitsio
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd third_party/cfitsio
 mkdir -p build
 cd build

--- a/build_scripts/build_cfitsio.sh
+++ b/build_scripts/build_cfitsio.sh
@@ -21,11 +21,17 @@ pushd "${ROOT_DIR}/third_party/cfitsio"
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
-echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
-echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
+fi
+if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
+fi
+if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+fi
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
     echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake

--- a/build_scripts/build_cfitsio.sh
+++ b/build_scripts/build_cfitsio.sh
@@ -17,7 +17,7 @@
 # Cfitsio
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
-pushd third_party/cfitsio
+pushd "${ROOT_DIR}/third_party/cfitsio"
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake

--- a/build_scripts/build_cfitsio.sh
+++ b/build_scripts/build_cfitsio.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Cfitsio
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/cfitsio"
 mkdir -p build

--- a/build_scripts/build_cfitsio.sh
+++ b/build_scripts/build_cfitsio.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Cfitsio
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/cfitsio"
 mkdir -p build

--- a/build_scripts/build_deps.sh
+++ b/build_scripts/build_deps.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-export ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+export SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+export ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
 export HOST_INSTALL_PREFIX=${HOST_INSTALL_PREFIX:-/usr/local}
 export INSTALL_PREFIX=${INSTALL_PREFIX:-$HOST_INSTALL_PREFIX}
 export CC_COMP=${CC_COMP:-gcc}

--- a/build_scripts/build_deps.sh
+++ b/build_scripts/build_deps.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
-export SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+export SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+export ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
 export HOST_INSTALL_PREFIX=${HOST_INSTALL_PREFIX:-/usr/local}
 export INSTALL_PREFIX=${INSTALL_PREFIX:-$HOST_INSTALL_PREFIX}
 export CC_COMP=${CC_COMP:-gcc}

--- a/build_scripts/build_deps.sh
+++ b/build_scripts/build_deps.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
-export ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-${SCRIPT_DIR}/..}")
 export HOST_INSTALL_PREFIX=${HOST_INSTALL_PREFIX:-/usr/local}
 export INSTALL_PREFIX=${INSTALL_PREFIX:-$HOST_INSTALL_PREFIX}
 source "${SCRIPT_DIR}/validate_toolchain_env.sh"

--- a/build_scripts/build_deps.sh
+++ b/build_scripts/build_deps.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=$(pwd)
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 export SCRIPT_DIR=$(cd $(dirname $0) && pwd)
 export HOST_INSTALL_PREFIX=${HOST_INSTALL_PREFIX:-/usr/local}
 export INSTALL_PREFIX=${INSTALL_PREFIX:-$HOST_INSTALL_PREFIX}
@@ -24,6 +24,7 @@ export WITH_FFMPEG=${WITH_FFMPEG:-1}
 export OPENCV_TOOLCHAIN_FILE=${OPENCV_TOOLCHAIN_FILE:-"linux/gnu.toolchain.cmake"}
 export CMAKE_TARGET_ARCH=${CMAKE_TARGET_ARCH:-$(uname -m)}
 export CLEANUP=${CLEANUP:-0}
+source "${SCRIPT_DIR}/validate_toolchain_env.sh"
 echo ${INSTALL_PREFIX}
 echo ${CC_COMP}
 echo ${CXX_COMP}

--- a/build_scripts/build_deps.sh
+++ b/build_scripts/build_deps.sh
@@ -40,11 +40,11 @@ echo ${EXTRA_LIBSND_FLAGS}
 echo ${CLEANUP}
 
 if [ "$CLEANUP" -eq 1 ]; then
-    git clean -fdx
-    git submodule init
-    git submodule update --init --recursive
-    git submodule foreach 'git clean -fdx'
-    git submodule foreach 'git checkout --force'
+    git -C "${ROOT_DIR}" clean -fdx
+    git -C "${ROOT_DIR}" submodule init
+    git -C "${ROOT_DIR}" submodule update --init --recursive
+    git -C "${ROOT_DIR}" submodule foreach 'git clean -fdx'
+    git -C "${ROOT_DIR}" submodule foreach 'git checkout --force'
 fi
 
 PACKAGE_LIST=(

--- a/build_scripts/build_deps.sh
+++ b/build_scripts/build_deps.sh
@@ -18,13 +18,13 @@ export SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 export ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
 export HOST_INSTALL_PREFIX=${HOST_INSTALL_PREFIX:-/usr/local}
 export INSTALL_PREFIX=${INSTALL_PREFIX:-$HOST_INSTALL_PREFIX}
+source "${SCRIPT_DIR}/validate_toolchain_env.sh"
 export CC_COMP=${CC_COMP:-gcc}
 export CXX_COMP=${CXX_COMP:-g++}
 export WITH_FFMPEG=${WITH_FFMPEG:-1}
 export OPENCV_TOOLCHAIN_FILE=${OPENCV_TOOLCHAIN_FILE:-"linux/gnu.toolchain.cmake"}
 export CMAKE_TARGET_ARCH=${CMAKE_TARGET_ARCH:-$(uname -m)}
 export CLEANUP=${CLEANUP:-0}
-source "${SCRIPT_DIR}/validate_toolchain_env.sh"
 echo ${INSTALL_PREFIX}
 echo ${CC_COMP}
 echo ${CXX_COMP}

--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 if [ ${WITH_FFMPEG} -gt 0 ]; then
     pushd "${ROOT_DIR}/third_party/FFmpeg"
     patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-01-CVE-2026-66037-iamf-count-label.patch

--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 if [ ${WITH_FFMPEG} -gt 0 ]; then
     pushd third_party/FFmpeg
     patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-01-CVE-2026-66037-iamf-count-label.patch

--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -17,7 +17,7 @@
 # For a snapshot of the code, see the README.rst
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 if [ ${WITH_FFMPEG} -gt 0 ]; then
-    pushd third_party/FFmpeg
+    pushd "${ROOT_DIR}/third_party/FFmpeg"
     patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-01-CVE-2026-66037-iamf-count-label.patch
     patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-02-CVE-2026-64834-rtpdec-asf-infinite-loop.patch
     patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-03-CVE-2026-64830-vobsub-stream-count.patch

--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
 if [ ${WITH_FFMPEG} -gt 0 ]; then
     pushd "${ROOT_DIR}/third_party/FFmpeg"
     patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-01-CVE-2026-66037-iamf-count-label.patch

--- a/build_scripts/build_ffmpeg.sh
+++ b/build_scripts/build_ffmpeg.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 if [ ${WITH_FFMPEG} -gt 0 ]; then
     pushd "${ROOT_DIR}/third_party/FFmpeg"
     patch -p1 < ${ROOT_DIR}/patches/ffmpeg/ffmpeg-01-CVE-2026-66037-iamf-count-label.patch

--- a/build_scripts/build_libflac.sh
+++ b/build_scripts/build_libflac.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # flac
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd third_party/flac
 mkdir -p build
 cd build

--- a/build_scripts/build_libflac.sh
+++ b/build_scripts/build_libflac.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # flac
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/flac"
 mkdir -p build

--- a/build_scripts/build_libflac.sh
+++ b/build_scripts/build_libflac.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # flac
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/flac"
 mkdir -p build
 cd build

--- a/build_scripts/build_libflac.sh
+++ b/build_scripts/build_libflac.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # flac
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/flac"
 mkdir -p build

--- a/build_scripts/build_libflac.sh
+++ b/build_scripts/build_libflac.sh
@@ -17,7 +17,7 @@
 # flac
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
-pushd third_party/flac
+pushd "${ROOT_DIR}/third_party/flac"
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake

--- a/build_scripts/build_libflac.sh
+++ b/build_scripts/build_libflac.sh
@@ -21,11 +21,17 @@ pushd "${ROOT_DIR}/third_party/flac"
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
-echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
-echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
+fi
+if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
+fi
+if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+fi
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
     echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake

--- a/build_scripts/build_libogg.sh
+++ b/build_scripts/build_libogg.sh
@@ -17,7 +17,7 @@
 # libogg
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
-pushd third_party/ogg
+pushd "${ROOT_DIR}/third_party/ogg"
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake

--- a/build_scripts/build_libogg.sh
+++ b/build_scripts/build_libogg.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # libogg
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/ogg"
 mkdir -p build

--- a/build_scripts/build_libogg.sh
+++ b/build_scripts/build_libogg.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # libogg
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/ogg"
 mkdir -p build

--- a/build_scripts/build_libogg.sh
+++ b/build_scripts/build_libogg.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # libogg
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/ogg"
 mkdir -p build
 cd build

--- a/build_scripts/build_libogg.sh
+++ b/build_scripts/build_libogg.sh
@@ -21,11 +21,17 @@ pushd "${ROOT_DIR}/third_party/ogg"
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
-echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
-echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
+fi
+if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
+fi
+if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+fi
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
     echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake

--- a/build_scripts/build_libogg.sh
+++ b/build_scripts/build_libogg.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # libogg
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd third_party/ogg
 mkdir -p build
 cd build

--- a/build_scripts/build_libopus.sh
+++ b/build_scripts/build_libopus.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 
 # libopus

--- a/build_scripts/build_libopus.sh
+++ b/build_scripts/build_libopus.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 
 # libopus

--- a/build_scripts/build_libopus.sh
+++ b/build_scripts/build_libopus.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 
 # libopus
 pushd "${ROOT_DIR}/third_party/opus"

--- a/build_scripts/build_libopus.sh
+++ b/build_scripts/build_libopus.sh
@@ -18,7 +18,7 @@ export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 
 # libopus
-pushd third_party/opus
+pushd "${ROOT_DIR}/third_party/opus"
 
 # Configure step relies on the git tag to generate the version
 # Since we only have a shallow copy of the submodule, without tags, the version can't be determined

--- a/build_scripts/build_libopus.sh
+++ b/build_scripts/build_libopus.sh
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export ROOT_DIR=$(pwd)
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 
 # libopus
 pushd third_party/opus

--- a/build_scripts/build_libopus.sh
+++ b/build_scripts/build_libopus.sh
@@ -30,11 +30,17 @@ git tag $OPUS_VERSION || true
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
-echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
-echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
+fi
+if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
+fi
+if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+fi
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
     echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake

--- a/build_scripts/build_libsndfile.sh
+++ b/build_scripts/build_libsndfile.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/libsndfile"
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065.patch
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065-extra-overflow-fixes.patch

--- a/build_scripts/build_libsndfile.sh
+++ b/build_scripts/build_libsndfile.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/libsndfile"
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065.patch

--- a/build_scripts/build_libsndfile.sh
+++ b/build_scripts/build_libsndfile.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/libsndfile"
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065.patch

--- a/build_scripts/build_libsndfile.sh
+++ b/build_scripts/build_libsndfile.sh
@@ -17,7 +17,7 @@
 # For a snapshot of the code, see the README.rst
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
-pushd third_party/libsndfile
+pushd "${ROOT_DIR}/third_party/libsndfile"
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065.patch
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065-extra-overflow-fixes.patch
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2024-50612.patch

--- a/build_scripts/build_libsndfile.sh
+++ b/build_scripts/build_libsndfile.sh
@@ -26,11 +26,17 @@ patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2025-56226-02-sndfile.patch
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
-echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
-echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
+fi
+if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
+fi
+if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+fi
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
     echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake

--- a/build_scripts/build_libsndfile.sh
+++ b/build_scripts/build_libsndfile.sh
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=$(pwd)
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd third_party/libsndfile
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065.patch
 patch -p1 < ${ROOT_DIR}/patches/libsnd-CVE-2022-33065-extra-overflow-fixes.patch

--- a/build_scripts/build_libtar.sh
+++ b/build_scripts/build_libtar.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 if [[ -n ${HOST_ARCH_OPTION:-} && ! $HOST_ARCH_OPTION =~ ^--host=[a-zA-Z0-9_-]+$ ]]; then
   echo "ERROR: HOST_ARCH_OPTION contains invalid characters" >&2
   exit 1

--- a/build_scripts/build_libtar.sh
+++ b/build_scripts/build_libtar.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
 if [[ -n ${HOST_ARCH_OPTION:-} && ! $HOST_ARCH_OPTION =~ ^--host=[a-zA-Z0-9_-]+$ ]]; then
   echo "ERROR: HOST_ARCH_OPTION contains invalid characters" >&2
   exit 1

--- a/build_scripts/build_libtar.sh
+++ b/build_scripts/build_libtar.sh
@@ -25,7 +25,7 @@ CONFIGURE_ARGS=(--prefix="${INSTALL_PREFIX}" --disable-shared)
 if [[ -n ${HOST_ARCH_OPTION:-} ]]; then
   CONFIGURE_ARGS+=("${HOST_ARCH_OPTION}")
 fi
-pushd third_party/libtar
+pushd "${ROOT_DIR}/third_party/libtar"
 patch -p1 < ${ROOT_DIR}/patches/libtar/libtar-1.2.20-CVE-2021-33643-CVE-2021-33644.patch
 patch -p1 < ${ROOT_DIR}/patches/libtar/libtar-1.2.20-CVE-2021-33645-CVE-2021-33646.patch
 autoreconf --force --install

--- a/build_scripts/build_libtar.sh
+++ b/build_scripts/build_libtar.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 if [[ -n ${HOST_ARCH_OPTION:-} && ! $HOST_ARCH_OPTION =~ ^--host=[a-zA-Z0-9_-]+$ ]]; then
   echo "ERROR: HOST_ARCH_OPTION contains invalid characters" >&2
   exit 1

--- a/build_scripts/build_libtar.sh
+++ b/build_scripts/build_libtar.sh
@@ -15,7 +15,16 @@
 # limitations under the License.
 
 # For a snapshot of the code, see the README.rst
-export ROOT_DIR=$(pwd)
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+if [[ -n ${HOST_ARCH_OPTION:-} && ! $HOST_ARCH_OPTION =~ ^--host=[a-zA-Z0-9_-]+$ ]]; then
+  echo "ERROR: HOST_ARCH_OPTION contains invalid characters" >&2
+  exit 1
+fi
+
+CONFIGURE_ARGS=(--prefix="${INSTALL_PREFIX}" --disable-shared)
+if [[ -n ${HOST_ARCH_OPTION:-} ]]; then
+  CONFIGURE_ARGS+=("${HOST_ARCH_OPTION}")
+fi
 pushd third_party/libtar
 patch -p1 < ${ROOT_DIR}/patches/libtar/libtar-1.2.20-CVE-2021-33643-CVE-2021-33644.patch
 patch -p1 < ${ROOT_DIR}/patches/libtar/libtar-1.2.20-CVE-2021-33645-CVE-2021-33646.patch
@@ -24,10 +33,7 @@ CC=${CC_COMP} \
 CXX=${CXX_COMP} \
 CFLAGS="-fPIC" \
 CXXFLAGS="-fPIC" \
-./configure \
-    ${HOST_ARCH_OPTION} \
-    --prefix=${INSTALL_PREFIX} \
-    --disable-shared
+./configure "${CONFIGURE_ARGS[@]}"
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 cd lib
 make install

--- a/build_scripts/build_libvorbis.sh
+++ b/build_scripts/build_libvorbis.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # libvorbis
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd third_party/vorbis
 mkdir -p build
 cd build

--- a/build_scripts/build_libvorbis.sh
+++ b/build_scripts/build_libvorbis.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # libvorbis
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/vorbis"
 mkdir -p build

--- a/build_scripts/build_libvorbis.sh
+++ b/build_scripts/build_libvorbis.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # libvorbis
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/vorbis"
 mkdir -p build
 cd build

--- a/build_scripts/build_libvorbis.sh
+++ b/build_scripts/build_libvorbis.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # libvorbis
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/vorbis"
 mkdir -p build

--- a/build_scripts/build_libvorbis.sh
+++ b/build_scripts/build_libvorbis.sh
@@ -17,7 +17,7 @@
 # libvorbis
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
-pushd third_party/vorbis
+pushd "${ROOT_DIR}/third_party/vorbis"
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake

--- a/build_scripts/build_libvorbis.sh
+++ b/build_scripts/build_libvorbis.sh
@@ -21,11 +21,17 @@ pushd "${ROOT_DIR}/third_party/vorbis"
 mkdir -p build
 cd build
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
-echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
-echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
+fi
+if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
+fi
+if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+fi
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
     echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake

--- a/build_scripts/build_lmdb.sh
+++ b/build_scripts/build_lmdb.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # LMDB
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
 pushd "${ROOT_DIR}/third_party/lmdb/libraries/liblmdb/"
 patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
     XCFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \

--- a/build_scripts/build_lmdb.sh
+++ b/build_scripts/build_lmdb.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # LMDB
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 pushd "${ROOT_DIR}/third_party/lmdb/libraries/liblmdb/"
 patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
     XCFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \

--- a/build_scripts/build_lmdb.sh
+++ b/build_scripts/build_lmdb.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # LMDB
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 pushd "${ROOT_DIR}/third_party/lmdb/libraries/liblmdb/"
 patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
     XCFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \

--- a/build_scripts/build_lmdb.sh
+++ b/build_scripts/build_lmdb.sh
@@ -16,7 +16,7 @@
 
 # LMDB
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
-pushd third_party/lmdb/libraries/liblmdb/
+pushd "${ROOT_DIR}/third_party/lmdb/libraries/liblmdb/"
 patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
     XCFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \
 make -j"$(grep ^processor /proc/cpuinfo | wc -l)"

--- a/build_scripts/build_opencv.sh
+++ b/build_scripts/build_opencv.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # OpenCV
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 # Note: OpenCV's `imgcodecs` module (and its bundled JPEG/TIFF/OpenJPEG/PNG/WebP
 # image-format libraries) is only needed by DALI's test suite — production DALI
 # dropped the legacy image decoder. That is also why libjpeg-turbo, libtiff, and

--- a/build_scripts/build_opencv.sh
+++ b/build_scripts/build_opencv.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # OpenCV
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 # Note: OpenCV's `imgcodecs` module (and its bundled JPEG/TIFF/OpenJPEG/PNG/WebP
 # image-format libraries) is only needed by DALI's test suite — production DALI
 # dropped the legacy image decoder. That is also why libjpeg-turbo, libtiff, and

--- a/build_scripts/build_opencv.sh
+++ b/build_scripts/build_opencv.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # OpenCV
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
 # Note: OpenCV's `imgcodecs` module (and its bundled JPEG/TIFF/OpenJPEG/PNG/WebP
 # image-format libraries) is only needed by DALI's test suite — production DALI
 # dropped the legacy image decoder. That is also why libjpeg-turbo, libtiff, and

--- a/build_scripts/build_opencv.sh
+++ b/build_scripts/build_opencv.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # OpenCV
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 # Note: OpenCV's `imgcodecs` module (and its bundled JPEG/TIFF/OpenJPEG/PNG/WebP
 # image-format libraries) is only needed by DALI's test suite — production DALI
 # dropped the legacy image decoder. That is also why libjpeg-turbo, libtiff, and

--- a/build_scripts/build_opencv.sh
+++ b/build_scripts/build_opencv.sh
@@ -21,7 +21,7 @@ export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 # dropped the legacy image decoder. That is also why libjpeg-turbo, libtiff, and
 # openjpeg are no longer kept as standalone submodules in this repo: OpenCV's
 # in-tree copies are sufficient for the tests.
-pushd third_party/opencv
+pushd "${ROOT_DIR}/third_party/opencv"
 mkdir -p build
 cd build
 # Validate no path traversal

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # protobuf, make two steps for cross compilation if needed
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/protobuf"
 mkdir -p build

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # protobuf, make two steps for cross compilation if needed
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/protobuf"
 mkdir -p build

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -34,12 +34,18 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 make -j"${JOBS}"
 make install
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
   rm -rf *
   echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-  echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
-  echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
-  echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+  if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
+  fi
+  if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
+  fi
+  if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+  fi
   echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> toolchain.cmake
   echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
   echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -16,26 +16,12 @@
 
 # protobuf, make two steps for cross compilation if needed
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
-pushd third_party/protobuf
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+pushd "${ROOT_DIR}/third_party/protobuf"
 mkdir -p build
 cd build
 
-validate_alnum() {
-  local var_name=$1
-  local var_value=$2
-  if [[ ! "$var_value" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-    echo "ERROR: $var_name contains invalid characters" >&2
-    exit 1
-  fi
-}
-
-# Validate before use
 JOBS=$(nproc)
-
-validate_alnum CC_COMP "$CC_COMP"
-validate_alnum CXX_COMP "$CXX_COMP"
-validate_alnum CMAKE_TARGET_ARCH "$CMAKE_TARGET_ARCH"
-
 # Dprotobuf_FORCE_FETCH_DEPENDENCIES to ensure we don't use host dependencies
     CFLAGS="-fPIC" \
     CXXFLAGS="-fPIC -std=c++17" \

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # protobuf, make two steps for cross compilation if needed
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 pushd third_party/protobuf
 mkdir -p build
 cd build

--- a/build_scripts/build_protobuf.sh
+++ b/build_scripts/build_protobuf.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # protobuf, make two steps for cross compilation if needed
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/protobuf"
 mkdir -p build
 cd build

--- a/build_scripts/build_zlib.sh
+++ b/build_scripts/build_zlib.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 #zlib
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/zlib"
 mkdir -p build
 cd build

--- a/build_scripts/build_zlib.sh
+++ b/build_scripts/build_zlib.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 #zlib
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 source "${ROOT_DIR}/build_scripts/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/zlib"
 mkdir -p build

--- a/build_scripts/build_zlib.sh
+++ b/build_scripts/build_zlib.sh
@@ -16,25 +16,10 @@
 
 #zlib
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
-pushd third_party/zlib
+source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
+pushd "${ROOT_DIR}/third_party/zlib"
 mkdir -p build
 cd build
-
-# Validate before use
-if [[ ! "$CC_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CC_COMP contains invalid characters" >&2
-  exit 1
-fi
-# Validate before use
-if [[ ! "$CXX_COMP" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CXX_COMP contains invalid characters" >&2
-  exit 1
-fi
-# Validate before use
-if [[ ! "$CMAKE_TARGET_ARCH" =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
-  echo "ERROR: CMAKE_TARGET_ARCH contains invalid characters" >&2
-  exit 1
-fi
 
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
 echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake

--- a/build_scripts/build_zlib.sh
+++ b/build_scripts/build_zlib.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 #zlib
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$(dirname "${BASH_SOURCE[0]}")/validate_toolchain_env.sh"
 pushd "${ROOT_DIR}/third_party/zlib"
 mkdir -p build

--- a/build_scripts/build_zlib.sh
+++ b/build_scripts/build_zlib.sh
@@ -22,11 +22,17 @@ mkdir -p build
 cd build
 
 echo "set(CMAKE_SYSTEM_NAME Linux)" > toolchain.cmake
-echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
-echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
-echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+if [[ -n ${CMAKE_TARGET_ARCH:-} ]]; then
+    echo "set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_TARGET_ARCH})" >> toolchain.cmake
+fi
+if [[ -n ${CC_COMP:-} ]]; then
+    echo "set(CMAKE_C_COMPILER ${CC_COMP})" >> toolchain.cmake
+fi
+if [[ -n ${CXX_COMP:-} ]]; then
+    echo "set(CMAKE_CXX_COMPILER ${CXX_COMP})" >> toolchain.cmake
+fi
 # only when cross compiling
-if [ "${CC_COMP}" != "gcc" ]; then
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc ]]; then
     echo "set(CMAKE_FIND_ROOT_PATH ${INSTALL_PREFIX})" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
     echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake

--- a/build_scripts/build_zlib.sh
+++ b/build_scripts/build_zlib.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 #zlib
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 pushd third_party/zlib
 mkdir -p build
 cd build

--- a/build_scripts/build_zstd.sh
+++ b/build_scripts/build_zstd.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # zstandard compression library
-export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
 pushd "${ROOT_DIR}/third_party/zstd"
    CFLAGS="-fPIC" \
    CXXFLAGS="-fPIC" \

--- a/build_scripts/build_zstd.sh
+++ b/build_scripts/build_zstd.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # zstandard compression library
+export ROOT_DIR=${ROOT_DIR:-$(pwd)}
 pushd third_party/zstd
    CFLAGS="-fPIC" \
    CXXFLAGS="-fPIC" \

--- a/build_scripts/build_zstd.sh
+++ b/build_scripts/build_zstd.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # zstandard compression library
-export ROOT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..")
+export ROOT_DIR=$(realpath "${ROOT_DIR:-$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..}")
 pushd "${ROOT_DIR}/third_party/zstd"
    CFLAGS="-fPIC" \
    CXXFLAGS="-fPIC" \

--- a/build_scripts/build_zstd.sh
+++ b/build_scripts/build_zstd.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # zstandard compression library
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
+export ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 pushd "${ROOT_DIR}/third_party/zstd"
    CFLAGS="-fPIC" \
    CXXFLAGS="-fPIC" \

--- a/build_scripts/build_zstd.sh
+++ b/build_scripts/build_zstd.sh
@@ -16,7 +16,7 @@
 
 # zstandard compression library
 export ROOT_DIR=${ROOT_DIR:-$(pwd)}
-pushd third_party/zstd
+pushd "${ROOT_DIR}/third_party/zstd"
    CFLAGS="-fPIC" \
    CXXFLAGS="-fPIC" \
    CC=${CC_COMP} \

--- a/build_scripts/validate_toolchain_env.sh
+++ b/build_scripts/validate_toolchain_env.sh
@@ -20,6 +20,11 @@ if [[ ( -n ${CC_COMP:-} && -z ${CXX_COMP:-} ) ||
   exit 1
 fi
 
+if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc && -z ${CMAKE_TARGET_ARCH:-} ]]; then
+  echo "ERROR: CMAKE_TARGET_ARCH must be set for cross-compilation" >&2
+  exit 1
+fi
+
 for toolchain_var in CC_COMP CXX_COMP CMAKE_TARGET_ARCH; do
   if [[ -n ${!toolchain_var} && ! ${!toolchain_var} =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
     echo "ERROR: ${toolchain_var} contains invalid characters" >&2

--- a/build_scripts/validate_toolchain_env.sh
+++ b/build_scripts/validate_toolchain_env.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export CC_COMP=${CC_COMP:-gcc}
+export CXX_COMP=${CXX_COMP:-g++}
+export CMAKE_TARGET_ARCH=${CMAKE_TARGET_ARCH:-$(uname -m)}
+
 for toolchain_var in CC_COMP CXX_COMP CMAKE_TARGET_ARCH; do
   if [[ ! ${!toolchain_var} =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
     echo "ERROR: ${toolchain_var} contains invalid characters" >&2

--- a/build_scripts/validate_toolchain_env.sh
+++ b/build_scripts/validate_toolchain_env.sh
@@ -20,14 +20,18 @@ if [[ ( -n ${CC_COMP:-} && -z ${CXX_COMP:-} ) ||
   exit 1
 fi
 
-if [[ -n ${CC_COMP:-} && ${CC_COMP} != gcc && -z ${CMAKE_TARGET_ARCH:-} ]]; then
-  echo "ERROR: CMAKE_TARGET_ARCH must be set for cross-compilation" >&2
-  exit 1
-fi
-
 for toolchain_var in CC_COMP CXX_COMP CMAKE_TARGET_ARCH; do
   if [[ -n ${!toolchain_var} && ! ${!toolchain_var} =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
     echo "ERROR: ${toolchain_var} contains invalid characters" >&2
     exit 1
   fi
 done
+
+if [[ -n ${CC_COMP:-} && -z ${CMAKE_TARGET_ARCH:-} ]]; then
+  compiler_target=$("${CC_COMP}" -dumpmachine 2>/dev/null || true)
+  compiler_arch=${compiler_target%%-*}
+  if [[ -n ${compiler_arch} && ${compiler_arch} != "$(uname -m)" ]]; then
+    echo "ERROR: CMAKE_TARGET_ARCH must be set for cross-compilation" >&2
+    exit 1
+  fi
+fi

--- a/build_scripts/validate_toolchain_env.sh
+++ b/build_scripts/validate_toolchain_env.sh
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [[ ( -n ${CC_COMP:-} && -z ${CXX_COMP:-} ) ||
+      ( -z ${CC_COMP:-} && -n ${CXX_COMP:-} ) ]]; then
+  echo "ERROR: CC_COMP and CXX_COMP must be set together" >&2
+  exit 1
+fi
+
 for toolchain_var in CC_COMP CXX_COMP CMAKE_TARGET_ARCH; do
   if [[ -n ${!toolchain_var} && ! ${!toolchain_var} =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
     echo "ERROR: ${toolchain_var} contains invalid characters" >&2

--- a/build_scripts/validate_toolchain_env.sh
+++ b/build_scripts/validate_toolchain_env.sh
@@ -14,12 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export CC_COMP=${CC_COMP:-gcc}
-export CXX_COMP=${CXX_COMP:-g++}
-export CMAKE_TARGET_ARCH=${CMAKE_TARGET_ARCH:-$(uname -m)}
-
 for toolchain_var in CC_COMP CXX_COMP CMAKE_TARGET_ARCH; do
-  if [[ ! ${!toolchain_var} =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+  if [[ -n ${!toolchain_var} && ! ${!toolchain_var} =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
     echo "ERROR: ${toolchain_var} contains invalid characters" >&2
     exit 1
   fi

--- a/build_scripts/validate_toolchain_env.sh
+++ b/build_scripts/validate_toolchain_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# LMDB
-export ROOT_DIR=${ROOT_DIR:-$(pwd)}
-pushd third_party/lmdb/libraries/liblmdb/
-patch -p3 < ${ROOT_DIR}/patches/Makefile-lmdb.patch
-    XCFLAGS="-fPIC" CC=${CC_COMP} CXX=${CXX_COMP} prefix=${INSTALL_PREFIX} \
-make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
-prefix=${INSTALL_PREFIX} make install
-popd
+for toolchain_var in CC_COMP CXX_COMP CMAKE_TARGET_ARCH; do
+  if [[ ! ${!toolchain_var} =~ ^[a-zA-Z0-9/_.+-]+$ ]]; then
+    echo "ERROR: ${toolchain_var} contains invalid characters" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
Validate compiler and target-architecture environment values before they are
written to generated CMake toolchain files. This prevents malformed values
from being interpreted as CMake code when the scripts are run directly or
through build_deps.sh.

Pass OpenSSL compiler and flag variables as quoted environment assignments
instead of unquoted Configure arguments, and validate HOST_ARCH_OPTION before
passing it to libtar's configure script.

Set ROOT_DIR in every dependency build script only when the caller has not
already supplied it, allowing the scripts to be invoked from another working
directory without losing the intended repository root.

**Addresses:**
In build_libtar.sh, the HOST_ARCH_OPTION environment variable is used unquoted and unvalidated as an argument to the ./configure script. This variable is typically set to something like '--host=aarch64-linux-gnu' for cross-compilation. Since it's unquoted, word splitting could cause unexpected behavior if it contains spaces or special characters. However, ./configure is not a shell command interpreter - it processes arguments as autotools options.

In build_aws-sdk-cpp.sh, the LDFLAGS and CPPFLAGS environment variables are used unvalidated and unquoted when invoking OpenSSL's ./Configure script. While CC_COMP, CXX_COMP, and CMAKE_TARGET_ARCH are validated against a strict regex, LDFLAGS and CPPFLAGS (which come from the environment) are passed directly as arguments. An attacker controlling these environment variables could inject additional arguments to the Configure script. However, since OpenSSL's Configure is a Perl script that processes arguments, the impact is limited to modifying the OpenSSL build configuration rather than direct command execution.

Several build scripts (build_libsnd.sh, build_cfitsio.sh, build_libflac.sh, build_libogg.sh, build_libvorbis.sh, build_libopus.sh) write CC_COMP, CXX_COMP, and CMAKE_TARGET_ARCH environment variables directly into toolchain.cmake files without any input validation. While build_protobuf.sh, build_zlib.sh, and build_aws-sdk-cpp.sh validate these variables against a regex `^[a-zA-Z0-9/_.+-]+$`, the other scripts do not. An attacker who controls these environment variables could inject arbitrary CMake commands into the toolchain file (e.g., CC_COMP='gcc") \nexecute_process(COMMAND id)\nset(x "' would inject CMake code). However, exploiting this requires the attacker to already have control over the build environment.

